### PR TITLE
design: MCP page CRT terminal card

### DIFF
--- a/src/app/clarke-moyer-mcp-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-mcp-passing-guide/page.tsx
@@ -44,30 +44,35 @@ export default function MCPGuidePage() {
 
           <h2 className="not-prose text-2xl font-bold text-gray-900 mb-4 mt-10 border-l-4 border-gray-400 pl-4">The Story</h2>
 
-          {/* Retro Windows XP card */}
-          <div className="not-prose bg-gray-100 border border-gray-300 rounded-xl p-6 mb-6 font-mono relative overflow-hidden">
-            <div className="absolute top-3 right-3 bg-gray-200 border border-gray-400 text-gray-600 text-xs px-2 py-0.5 rounded font-sans font-semibold">🖥️ Vintage Credential</div>
-            <p className="text-gray-700 text-sm leading-relaxed mb-3">
-              I got my MCP in March 2009 — and yes, it was a <strong>Windows XP certification</strong>. If you&rsquo;re
-              wondering how long ago that was: the &ldquo;P&rdquo; in XP stood for &ldquo;Professional,&rdquo; not
-              &ldquo;Please upgrade already.&rdquo;
-            </p>
-            <p className="text-gray-700 text-sm leading-relaxed mb-3">
-              At the time, the MCP was a hard prerequisite. SAIC and DCGS required it before they&rsquo;d even consider
-              hiring you. It wasn&rsquo;t optional, it wasn&rsquo;t a nice-to-have — it was the ticket you had to punch
-              to get in the door. So I punched it.
-            </p>
-            <p className="text-gray-700 text-sm leading-relaxed mb-3">
-              This was the <strong>before cloud era</strong>. Microsoft certifications in 2009 meant knowing your way
-              around a domain controller and Active Directory. You didn&rsquo;t &ldquo;spin up resources&rdquo; — you
-              physically racked servers. Group Policy was the closest thing to infrastructure-as-code, and DNS was
-              something you fixed at 2am with a prayer and a server reboot.
-            </p>
-            <p className="text-gray-700 text-sm leading-relaxed">
-              The MCP was the entry credential to everything else in the Microsoft ecosystem at the time: MCSA, MCSE,
-              MCDBA. It said &ldquo;this person passed at least one Microsoft exam and can be trusted near a Windows
-              server.&rdquo; That was the bar.
-            </p>
+          {/* CRT Terminal Card */}
+          <div className="not-prose my-8 rounded-lg overflow-hidden border-4 border-gray-600 shadow-2xl" style={{background: '#0a0a0a'}}>
+            {/* Monitor bezel top */}
+            <div className="flex items-center gap-2 px-4 py-2 bg-gray-800 border-b border-gray-600">
+              <span className="text-2xl">💾</span>
+              <span className="text-gray-400 text-xs font-mono tracking-widest">VINTAGE CREDENTIAL</span>
+              <span className="ml-auto text-gray-600 text-xs font-mono">©1998 MICROSOFT CORP</span>
+            </div>
+            {/* CRT screen */}
+            <div className="p-6 font-mono text-green-400 text-sm leading-relaxed relative overflow-hidden"
+              style={{
+                background: 'repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0,0,0,0.15) 2px, rgba(0,0,0,0.15) 4px)',
+                textShadow: '0 0 8px rgba(74, 222, 128, 0.8)'
+              }}>
+              <p className="mb-1">C:\CERTIFICATIONS&gt; dir MCP.exe</p>
+              <p className="mb-1 text-green-300">Microsoft Certified Professional (MCP)</p>
+              <p className="mb-1">Certification ID: <span className="text-green-200">A2100-0009</span></p>
+              <p className="mb-1">Exam: <span className="text-green-200">Windows XP Professional</span></p>
+              <p className="mb-1">Obtained: <span className="text-green-200">2009</span></p>
+              <p className="mb-1">Status: <span className="text-yellow-400">RETIRED</span></p>
+              <p className="mb-3">Required for: <span className="text-green-200">SAIC / DCGS hire</span></p>
+              <p className="text-green-600">C:\CERTIFICATIONS&gt; <span className="animate-pulse">_</span></p>
+            </div>
+            {/* Monitor bottom bezel */}
+            <div className="bg-gray-800 border-t border-gray-600 px-4 py-2 flex items-center gap-4">
+              <div className="w-2 h-2 rounded-full bg-green-500 shadow-sm" style={{boxShadow: '0 0 6px #22c55e'}}></div>
+              <span className="text-gray-500 text-xs font-mono">POWER ON</span>
+              <span className="ml-auto text-gray-600 text-xs font-mono">640×480 VGA</span>
+            </div>
           </div>
 
           <p className="text-gray-700 mb-6">


### PR DESCRIPTION
Upgrades the vintage credential section on the MCP page to a proper CRT terminal aesthetic: green phosphor text, scanline overlay, glowing text-shadow, floppy disk badge, blinking cursor.