### PR TITLE
feat: pre-cutover essentials — 404 page, schema markup, contact form, robots.txt

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -200,4 +200,9 @@
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
+  <url>
+    <loc>https://clarkemoyer.com/contact/</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/src/app/clarke-moyer-cissp-certification-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-cissp-certification-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer CISSP Certification Passing Guide',
@@ -25,6 +26,11 @@ function amzn(asin: string, label: string) {
 export default function CISSPGuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'CISSP Certification Passing Guide', url: '/clarke-moyer-cissp-certification-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-cissp-issep-certification-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-cissp-issep-certification-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer CISSP-ISSEP Certification Passing Guide',
@@ -32,6 +33,11 @@ function amznSearch(searchUrl: string, label: string) {
 export default function CISSPISSEPGuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'CISSP-ISSEP Guide', url: '/clarke-moyer-cissp-issep-certification-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-ciw-professional-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-ciw-professional-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer CIW Professional Certification Passing Guide',
@@ -17,6 +18,11 @@ const AMZN_TAG = 'clarkemoyer-20';
 export default function CIWProfessionalGuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'CIW Professional Guide', url: '/clarke-moyer-ciw-professional-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-comptia-a-plus-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-comptia-a-plus-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer CompTIA A+ Certification Passing Guide',
@@ -24,6 +25,11 @@ function amzn(url: string, label: string) {
 export default function APlusGuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'A+ Guide', url: '/clarke-moyer-comptia-a-plus-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-comptia-network-plus-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-comptia-network-plus-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer CompTIA Network+ Certification Passing Guide',
@@ -24,6 +25,11 @@ function amzn(url: string, label: string) {
 export default function NetworkPlusGuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'Network+ Guide', url: '/clarke-moyer-comptia-network-plus-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-comptia-project-plus-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-comptia-project-plus-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer CompTIA Project+ Certification Passing Guide',
@@ -24,6 +25,11 @@ function amzn(url: string, label: string) {
 export default function ProjectPlusGuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'Project+ Guide', url: '/clarke-moyer-comptia-project-plus-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-comptia-security-plus-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-comptia-security-plus-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer CompTIA Security+ Certification Passing Guide',
@@ -24,6 +25,11 @@ function amzn(url: string, label: string) {
 export default function SecurityPlusGuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'Security+ Guide', url: '/clarke-moyer-comptia-security-plus-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-itil-4-foundation-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-itil-4-foundation-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer ITIL 4 Foundation Certification Passing Guide',
@@ -24,6 +25,11 @@ function amzn(url: string, label: string) {
 export default function ITIL4FoundationGuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'ITIL 4 Foundation Guide', url: '/clarke-moyer-itil-4-foundation-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-mcp-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-mcp-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer Microsoft MCP Certification Passing Guide',
@@ -15,6 +16,11 @@ export const metadata: Metadata = {
 export default function MCPGuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'MCP Guide', url: '/clarke-moyer-mcp-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-microsoft-ai-900-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-microsoft-ai-900-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer Microsoft AI-900 Azure AI Fundamentals Passing Guide',
@@ -25,6 +26,11 @@ function amzn(asin: string, label: string) {
 export default function AI900GuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'AI-900 Guide', url: '/clarke-moyer-microsoft-ai-900-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-microsoft-az-500-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-microsoft-az-500-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer AZ-500 Microsoft Azure Security Technologies Passing Guide',
@@ -17,6 +18,11 @@ const AMZN_TAG = 'clarkemoyer-20';
 export default function AZ500GuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'AZ-500 Azure Security Technologies', url: '/clarke-moyer-microsoft-az-500-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-microsoft-az-900-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-microsoft-az-900-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer Microsoft AZ-900 Azure Fundamentals Passing Guide',
@@ -25,6 +26,11 @@ function amzn(asin: string, label: string) {
 export default function AZ900GuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'AZ-900 Guide', url: '/clarke-moyer-microsoft-az-900-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-microsoft-ms-900-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-microsoft-ms-900-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer Microsoft MS-900 Microsoft 365 Fundamentals Passing Guide',
@@ -34,6 +35,11 @@ function amznSearch(query: string, label: string) {
 export default function MS900GuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'MS-900 Guide', url: '/clarke-moyer-microsoft-ms-900-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-microsoft-sc-500-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-microsoft-sc-500-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer Microsoft SC-500 Cloud AI Security Engineer Passing Guide',
@@ -34,6 +35,11 @@ function amznSearch(query: string, label: string) {
 export default function SC500GuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'SC-500 Guide', url: '/clarke-moyer-microsoft-sc-500-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-microsoft-sc-900-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-microsoft-sc-900-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer Microsoft SC-900 Security Fundamentals Passing Guide',
@@ -25,6 +26,11 @@ function amzn(asin: string, label: string) {
 export default function SC900GuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'SC-900 Guide', url: '/clarke-moyer-microsoft-sc-900-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-philly-cheesesteak-recipe/page.tsx
+++ b/src/app/clarke-moyer-philly-cheesesteak-recipe/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { amznUrl } from '@/lib/amazon';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: "Clarke Moyer's Philly Cheesesteak Recipe",
@@ -24,6 +25,12 @@ function amzn(asin: string, label: string) {
 export default function PhillyCheesesteakPage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Fun', url: '/fun/' },
+        { name: 'Cooking', url: '/cooking/' },
+        { name: 'Philly Cheesesteak', url: '/clarke-moyer-philly-cheesesteak-recipe/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-pmp-certification-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-pmp-certification-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer PMP Certification Passing Guide',
@@ -25,6 +26,11 @@ function amzn(asin: string, label: string) {
 export default function PMPGuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'PMP Guide', url: '/clarke-moyer-pmp-certification-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-safe-spc-certification-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-safe-spc-certification-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer SAFe SPC Certification Passing Guide',
@@ -25,6 +26,11 @@ function amzn(asin: string, label: string) {
 export default function SAFeSPCGuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'SAFe SPC Guide', url: '/clarke-moyer-safe-spc-certification-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-sweet-tea-recipe/page.tsx
+++ b/src/app/clarke-moyer-sweet-tea-recipe/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { amznUrl } from '@/lib/amazon';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: "Clarke Moyer's Sweet Tea Recipe",
@@ -24,6 +25,12 @@ function amzn(asin: string, label: string) {
 export default function SweetTeaPage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Fun', url: '/fun/' },
+        { name: 'Cooking', url: '/cooking/' },
+        { name: 'Sweet Tea', url: '/clarke-moyer-sweet-tea-recipe/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-vcp-am-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-vcp-am-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer VMware VCP-AM Application Modernization Passing Guide',
@@ -24,6 +25,11 @@ function amznSearch(url: string, label: string) {
 export default function VCPAMGuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'VCP-AM Guide', url: '/clarke-moyer-vcp-am-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-vcp4-dcv-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-vcp4-dcv-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer VMware VCP4-DCV Certification Passing Guide',
@@ -17,6 +18,11 @@ const AMZN_TAG = 'clarkemoyer-20';
 export default function VCP4DCVGuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'VCP4-DCV Guide', url: '/clarke-moyer-vcp4-dcv-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-vcp5-dcv-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-vcp5-dcv-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer VMware VCP5-DCV Certification Passing Guide',
@@ -17,6 +18,11 @@ const AMZN_TAG = 'clarkemoyer-20';
 export default function VCP5DCVGuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'VCP5-DCV Guide', url: '/clarke-moyer-vcp5-dcv-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-vcp6-cma-passing-guide/page.tsx
+++ b/src/app/clarke-moyer-vcp6-cma-passing-guide/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Clarke Moyer VMware VCP6-CMA Certification Passing Guide',
@@ -24,6 +25,11 @@ function amznSearch(url: string, label: string) {
 export default function VCP6CMAGuidePage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Certification Guides', url: '/certification-guides/' },
+        { name: 'VCP6-CMA Guide', url: '/clarke-moyer-vcp6-cma-passing-guide/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/clarke-moyer-world-famous-apple-crisp-recipe/page.tsx
+++ b/src/app/clarke-moyer-world-famous-apple-crisp-recipe/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { amznUrl } from '@/lib/amazon';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: "Clarke Moyer's World Famous Apple Crisp Recipe",
@@ -24,6 +25,12 @@ function amzn(asin: string, label: string) {
 export default function AppleCrispPage() {
   return (
     <>
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Fun', url: '/fun/' },
+        { name: 'Cooking', url: '/cooking/' },
+        { name: 'Apple Crisp', url: '/clarke-moyer-world-famous-apple-crisp-recipe/' },
+      ])} />
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-2">

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,227 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
+
+export const metadata: Metadata = {
+  title: 'Contact | Clarke Moyer',
+  description:
+    'Get in touch with Clarke Moyer for Walk and Talk consulting sessions, speaking engagements, or Free For Charity nonprofit assistance.',
+  openGraph: {
+    title: 'Contact | Clarke Moyer',
+    description:
+      'Get in touch with Clarke Moyer for Walk and Talk consulting, speaking engagements, or Free For Charity inquiries.',
+    type: 'website',
+    url: '/contact/',
+  },
+};
+
+const BOOK_MAIN =
+  'https://outlook.office.com/bookwithme/user/6a2b9209a2654d8e9f83499a2218eec3@moyermanagement.com?anonymous&ismsaljsauthenabled&ep=plink';
+
+export default function ContactPage() {
+  return (
+    <>
+      <SchemaScript
+        schema={breadcrumbSchema([
+          { name: 'Home', url: '/' },
+          { name: 'Contact', url: '/contact/' },
+        ])}
+      />
+
+      {/* ── Hero ── */}
+      <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-36 pb-16 px-4">
+        <div className="text-center text-white max-w-3xl">
+          <div className="text-sm mb-4 text-gray-400">
+            <Link href="/" className="hover:underline text-gray-300">
+              Home
+            </Link>
+            {' / '}Contact
+          </div>
+          <h1 className="text-4xl md:text-5xl font-bold mb-4">Get in Touch</h1>
+          <p className="text-xl text-gray-300 max-w-xl mx-auto leading-relaxed">
+            Questions about consulting, speaking engagements, or nonprofit help — start here.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Two-Column Info ── */}
+      <section className="bg-white py-16">
+        <div className="max-w-5xl mx-auto px-4">
+          <div className="grid md:grid-cols-2 gap-12">
+            {/* Walk and Talk */}
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900 mb-4">Walk and Talk Inquiry</h2>
+              <p className="text-gray-700 mb-6 leading-relaxed">
+                Interested in a Walk and Talk session? You can book directly via Microsoft Bookings — no
+                back-and-forth required. Or send a message below if you have questions first.
+              </p>
+              <a
+                href={BOOK_MAIN}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block bg-gray-900 hover:bg-gray-700 text-white font-semibold px-6 py-3 rounded transition-colors"
+              >
+                Book a Session Now →
+              </a>
+              <p className="text-gray-500 text-sm mt-4">
+                Two sessions available daily · Mon–Fri · Limited availability
+              </p>
+            </div>
+
+            {/* Speaking */}
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900 mb-4">Speaking Engagements</h2>
+              <p className="text-gray-700 mb-4 leading-relaxed">
+                Clarke is available for keynote presentations, conference sessions, and executive retreats.
+                Fill out the form below to inquire about availability and topics.
+              </p>
+              <ul className="space-y-2 text-gray-700 text-sm mb-4">
+                <li className="flex items-start gap-2">
+                  <span className="text-gray-400 mt-0.5">•</span>Industry conference keynotes
+                </li>
+                <li className="flex items-start gap-2">
+                  <span className="text-gray-400 mt-0.5">•</span>Executive offsite retreats
+                </li>
+                <li className="flex items-start gap-2">
+                  <span className="text-gray-400 mt-0.5">•</span>Leadership team workshops
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Contact Form ── */}
+      <section className="bg-gray-50 py-16">
+        <div className="max-w-2xl mx-auto px-4">
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">Send a Message</h2>
+          <p className="text-gray-600 mb-8 text-sm">
+            Your information is used only to respond to your inquiry. Clarke does not sell or share
+            contact information.
+          </p>
+
+          {/* Formspree form — Clarke needs to replace PLACEHOLDER with real endpoint */}
+          <form
+            action="https://formspree.io/f/PLACEHOLDER"
+            method="POST"
+            className="space-y-6"
+          >
+            {/* Name */}
+            <div>
+              <label htmlFor="name" className="block text-sm font-semibold text-gray-700 mb-1">
+                Name <span className="text-red-500">*</span>
+              </label>
+              <input
+                id="name"
+                name="name"
+                type="text"
+                required
+                className="w-full border border-gray-300 rounded px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent"
+                placeholder="Your full name"
+              />
+            </div>
+
+            {/* Email */}
+            <div>
+              <label htmlFor="email" className="block text-sm font-semibold text-gray-700 mb-1">
+                Email <span className="text-red-500">*</span>
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                required
+                className="w-full border border-gray-300 rounded px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent"
+                placeholder="you@example.com"
+              />
+            </div>
+
+            {/* Organization */}
+            <div>
+              <label htmlFor="organization" className="block text-sm font-semibold text-gray-700 mb-1">
+                Organization
+              </label>
+              <input
+                id="organization"
+                name="organization"
+                type="text"
+                className="w-full border border-gray-300 rounded px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent"
+                placeholder="Your company or organization"
+              />
+            </div>
+
+            {/* Inquiry Type */}
+            <div>
+              <label htmlFor="inquiry_type" className="block text-sm font-semibold text-gray-700 mb-1">
+                Inquiry Type <span className="text-red-500">*</span>
+              </label>
+              <select
+                id="inquiry_type"
+                name="inquiry_type"
+                required
+                className="w-full border border-gray-300 rounded px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent bg-white"
+              >
+                <option value="">Select an inquiry type…</option>
+                <option value="Walk and Talk Question">Walk and Talk Question</option>
+                <option value="Speaking Engagement">Speaking Engagement</option>
+                <option value="Free For Charity (Nonprofit)">Free For Charity (Nonprofit)</option>
+                <option value="Other">Other</option>
+              </select>
+            </div>
+
+            {/* Message */}
+            <div>
+              <label htmlFor="message" className="block text-sm font-semibold text-gray-700 mb-1">
+                Message <span className="text-red-500">*</span>
+              </label>
+              <textarea
+                id="message"
+                name="message"
+                required
+                rows={5}
+                className="w-full border border-gray-300 rounded px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent resize-y"
+                placeholder="Tell Clarke what's on your mind…"
+              />
+            </div>
+
+            {/* How did you hear */}
+            <div>
+              <label htmlFor="referral_source" className="block text-sm font-semibold text-gray-700 mb-1">
+                How did you hear about Clarke?
+              </label>
+              <input
+                id="referral_source"
+                name="referral_source"
+                type="text"
+                className="w-full border border-gray-300 rounded px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent"
+                placeholder="LinkedIn, Google search, colleague, etc."
+              />
+            </div>
+
+            <button
+              type="submit"
+              className="w-full bg-gray-900 hover:bg-gray-700 text-white font-semibold py-3 px-6 rounded transition-colors"
+            >
+              Send Message →
+            </button>
+          </form>
+
+          {/* Action note for Clarke */}
+          <div className="mt-8 bg-amber-50 border-l-4 border-amber-500 p-4 text-sm text-amber-900">
+            <strong>Note for Clarke:</strong> Replace <code>PLACEHOLDER</code> in the form action URL with
+            your real Formspree endpoint. Create a free account at{' '}
+            <a
+              href="https://formspree.io"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              formspree.io
+            </a>{' '}
+            and create a new form to get your endpoint.
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -28,197 +28,93 @@ export default function ContactPage() {
         ])}
       />
 
-      {/* ── Hero ── */}
-      <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-36 pb-16 px-4">
+      {/* Hero */}
+      <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-3xl">
-          <div className="text-sm mb-4 text-gray-400">
-            <Link href="/" className="hover:underline text-gray-300">
-              Home
-            </Link>
-            {' / '}Contact
-          </div>
+          <nav aria-label="Breadcrumb" className="text-sm mb-4">
+            <Link href="/" className="hover:underline text-gray-300">Home</Link>
+            {' / '}
+            <span className="text-gray-400">Contact</span>
+          </nav>
           <h1 className="text-4xl md:text-5xl font-bold mb-4">Get in Touch</h1>
-          <p className="text-xl text-gray-300 max-w-xl mx-auto leading-relaxed">
-            Questions about consulting, speaking engagements, or nonprofit help — start here.
+          <p className="text-gray-300 text-lg">
+            Two ways to reach Clarke — direct and no friction.
           </p>
         </div>
       </section>
 
-      {/* ── Two-Column Info ── */}
+      {/* Contact options */}
       <section className="bg-white py-16">
-        <div className="max-w-5xl mx-auto px-4">
-          <div className="grid md:grid-cols-2 gap-12">
-            {/* Walk and Talk */}
-            <div>
-              <h2 className="text-2xl font-bold text-gray-900 mb-4">Walk and Talk Inquiry</h2>
-              <p className="text-gray-700 mb-6 leading-relaxed">
-                Interested in a Walk and Talk session? You can book directly via Microsoft Bookings — no
-                back-and-forth required. Or send a message below if you have questions first.
+        <div className="max-w-3xl mx-auto px-4">
+
+          {/* Text */}
+          <div className="bg-gray-900 rounded-2xl p-8 mb-6 text-white flex flex-col md:flex-row items-center gap-6">
+            <div className="text-5xl" aria-hidden="true">💬</div>
+            <div className="flex-1">
+              <h2 className="text-2xl font-bold mb-2">Send a Text</h2>
+              <p className="text-gray-300 mb-4">
+                The fastest way to reach Clarke. Text him directly — no voicemail, no gatekeeper.
+              </p>
+              <a
+                href="sms:5202228104"
+                className="inline-block bg-white text-gray-900 font-bold px-8 py-3 rounded-full hover:bg-gray-100 transition-colors text-lg"
+              >
+                Text (520) 222-8104 →
+              </a>
+            </div>
+          </div>
+
+          {/* LinkedIn */}
+          <div className="bg-blue-50 border border-blue-200 rounded-2xl p-8 mb-6 flex flex-col md:flex-row items-center gap-6">
+            <div className="text-5xl" aria-hidden="true">🔗</div>
+            <div className="flex-1">
+              <h2 className="text-2xl font-bold text-blue-900 mb-2">Connect on LinkedIn</h2>
+              <p className="text-blue-800 mb-4">
+                Send a connection request or message Clarke directly on LinkedIn.
+              </p>
+              <a
+                href="https://www.linkedin.com/in/clarkemoyer"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block bg-blue-700 hover:bg-blue-800 text-white font-bold px-8 py-3 rounded-full transition-colors text-lg"
+              >
+                LinkedIn: Clarke Moyer →
+              </a>
+            </div>
+          </div>
+
+          {/* Book directly */}
+          <div className="bg-green-50 border border-green-200 rounded-2xl p-8 mb-10 flex flex-col md:flex-row items-center gap-6">
+            <div className="text-5xl" aria-hidden="true">📅</div>
+            <div className="flex-1">
+              <h2 className="text-2xl font-bold text-green-900 mb-2">Ready to Book?</h2>
+              <p className="text-green-800 mb-4">
+                Skip the back-and-forth — book a Walk and Talk session directly via Microsoft Bookings.
               </p>
               <a
                 href={BOOK_MAIN}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-block bg-gray-900 hover:bg-gray-700 text-white font-semibold px-6 py-3 rounded transition-colors"
+                className="inline-block bg-green-700 hover:bg-green-800 text-white font-bold px-8 py-3 rounded-full transition-colors text-lg"
               >
-                Book a Session Now →
+                Book a Walk and Talk →
               </a>
-              <p className="text-gray-500 text-sm mt-4">
-                Two sessions available daily · Mon–Fri · Limited availability
-              </p>
-            </div>
-
-            {/* Speaking */}
-            <div>
-              <h2 className="text-2xl font-bold text-gray-900 mb-4">Speaking Engagements</h2>
-              <p className="text-gray-700 mb-4 leading-relaxed">
-                Clarke is available for keynote presentations, conference sessions, and executive retreats.
-                Fill out the form below to inquire about availability and topics.
-              </p>
-              <ul className="space-y-2 text-gray-700 text-sm mb-4">
-                <li className="flex items-start gap-2">
-                  <span className="text-gray-400 mt-0.5">•</span>Industry conference keynotes
-                </li>
-                <li className="flex items-start gap-2">
-                  <span className="text-gray-400 mt-0.5">•</span>Executive offsite retreats
-                </li>
-                <li className="flex items-start gap-2">
-                  <span className="text-gray-400 mt-0.5">•</span>Leadership team workshops
-                </li>
-              </ul>
             </div>
           </div>
-        </div>
-      </section>
 
-      {/* ── Contact Form ── */}
-      <section className="bg-gray-50 py-16">
-        <div className="max-w-2xl mx-auto px-4">
-          <h2 className="text-2xl font-bold text-gray-900 mb-2">Send a Message</h2>
-          <p className="text-gray-600 mb-8 text-sm">
-            Your information is used only to respond to your inquiry. Clarke does not sell or share
-            contact information.
-          </p>
+          {/* Nonprofit callout */}
+          <div className="not-prose bg-amber-50 border-l-4 border-amber-500 p-5 rounded-r-lg mb-10">
+            <p className="font-bold text-amber-900">🎁 Nonprofit? Walk and Talk is free.</p>
+            <p className="text-amber-800 text-sm mt-1">
+              Registered 501(c)(3) nonprofits receive Walk and Talk at no cost through{' '}
+              <a href="https://freeforcharity.org" target="_blank" rel="noopener noreferrer" className="underline">
+                Free For Charity
+              </a>.
+            </p>
+          </div>
 
-          {/* Formspree form — Clarke needs to replace PLACEHOLDER with real endpoint */}
-          <form
-            action="https://formspree.io/f/PLACEHOLDER"
-            method="POST"
-            className="space-y-6"
-          >
-            {/* Name */}
-            <div>
-              <label htmlFor="name" className="block text-sm font-semibold text-gray-700 mb-1">
-                Name <span className="text-red-500">*</span>
-              </label>
-              <input
-                id="name"
-                name="name"
-                type="text"
-                required
-                className="w-full border border-gray-300 rounded px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent"
-                placeholder="Your full name"
-              />
-            </div>
-
-            {/* Email */}
-            <div>
-              <label htmlFor="email" className="block text-sm font-semibold text-gray-700 mb-1">
-                Email <span className="text-red-500">*</span>
-              </label>
-              <input
-                id="email"
-                name="email"
-                type="email"
-                required
-                className="w-full border border-gray-300 rounded px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent"
-                placeholder="you@example.com"
-              />
-            </div>
-
-            {/* Organization */}
-            <div>
-              <label htmlFor="organization" className="block text-sm font-semibold text-gray-700 mb-1">
-                Organization
-              </label>
-              <input
-                id="organization"
-                name="organization"
-                type="text"
-                className="w-full border border-gray-300 rounded px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent"
-                placeholder="Your company or organization"
-              />
-            </div>
-
-            {/* Inquiry Type */}
-            <div>
-              <label htmlFor="inquiry_type" className="block text-sm font-semibold text-gray-700 mb-1">
-                Inquiry Type <span className="text-red-500">*</span>
-              </label>
-              <select
-                id="inquiry_type"
-                name="inquiry_type"
-                required
-                className="w-full border border-gray-300 rounded px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent bg-white"
-              >
-                <option value="">Select an inquiry type…</option>
-                <option value="Walk and Talk Question">Walk and Talk Question</option>
-                <option value="Speaking Engagement">Speaking Engagement</option>
-                <option value="Free For Charity (Nonprofit)">Free For Charity (Nonprofit)</option>
-                <option value="Other">Other</option>
-              </select>
-            </div>
-
-            {/* Message */}
-            <div>
-              <label htmlFor="message" className="block text-sm font-semibold text-gray-700 mb-1">
-                Message <span className="text-red-500">*</span>
-              </label>
-              <textarea
-                id="message"
-                name="message"
-                required
-                rows={5}
-                className="w-full border border-gray-300 rounded px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent resize-y"
-                placeholder="Tell Clarke what's on your mind…"
-              />
-            </div>
-
-            {/* How did you hear */}
-            <div>
-              <label htmlFor="referral_source" className="block text-sm font-semibold text-gray-700 mb-1">
-                How did you hear about Clarke?
-              </label>
-              <input
-                id="referral_source"
-                name="referral_source"
-                type="text"
-                className="w-full border border-gray-300 rounded px-4 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent"
-                placeholder="LinkedIn, Google search, colleague, etc."
-              />
-            </div>
-
-            <button
-              type="submit"
-              className="w-full bg-gray-900 hover:bg-gray-700 text-white font-semibold py-3 px-6 rounded transition-colors"
-            >
-              Send Message →
-            </button>
-          </form>
-
-          {/* Action note for Clarke */}
-          <div className="mt-8 bg-amber-50 border-l-4 border-amber-500 p-4 text-sm text-amber-900">
-            <strong>Note for Clarke:</strong> Replace <code>PLACEHOLDER</code> in the form action URL with
-            your real Formspree endpoint. Create a free account at{' '}
-            <a
-              href="https://formspree.io"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline"
-            >
-              formspree.io
-            </a>{' '}
-            and create a new form to get your endpoint.
+          <div className="text-center">
+            <Link href="/" className="text-blue-600 hover:underline font-medium">← Back to Home</Link>
           </div>
         </div>
       </section>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Script from "next/script";
 import "./globals.css";
 import CookieConsent from '@/components/cookie-consent';
+import { personSchema, SchemaScript } from '@/lib/schema';
 
 const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID || '';
 
@@ -31,6 +32,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
+        <SchemaScript schema={personSchema()} />
         {/* Google Tag Manager — only loaded when GTM_ID is configured */}
         {GTM_ID && (
           <Script id="gtm-head" strategy="afterInteractive">{`

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function NotFound() {
   return (
-    <>
+    <main>
       {/* Dark hero */}
       <section className="relative min-h-[60vh] bg-gray-900 flex items-center justify-center px-4">
         <div className="text-center text-white max-w-2xl">
@@ -39,6 +39,6 @@ export default function NotFound() {
           </div>
         </div>
       </section>
-    </>
+    </main>
   )
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: '404 — Page Not Found | Clarke Moyer',
+  description: 'The page you were looking for could not be found.',
+}
+
+export default function NotFound() {
+  return (
+    <>
+      {/* Dark hero */}
+      <section className="relative min-h-[60vh] bg-gray-900 flex items-center justify-center px-4">
+        <div className="text-center text-white max-w-2xl">
+          <div className="text-8xl font-bold text-gray-700 mb-4">404</div>
+          <h1 className="text-3xl md:text-4xl font-bold mb-4">Page Not Found</h1>
+          <p className="text-gray-300 text-lg mb-8">
+            The page you were looking for doesn&rsquo;t exist or may have moved.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Link
+              href="/"
+              className="bg-white text-gray-900 font-semibold px-8 py-3 rounded-full hover:bg-gray-100 transition-colors"
+            >
+              ← Back to Home
+            </Link>
+            <Link
+              href="/walk-and-talk/"
+              className="border border-white text-white font-semibold px-8 py-3 rounded-full hover:bg-white/10 transition-colors"
+            >
+              Book a Walk and Talk
+            </Link>
+            <Link
+              href="/certification-guides/"
+              className="border border-white text-white font-semibold px-8 py-3 rounded-full hover:bg-white/10 transition-colors"
+            >
+              Certification Guides
+            </Link>
+          </div>
+        </div>
+      </section>
+    </>
+  )
+}

--- a/src/app/walk-and-talk/page.tsx
+++ b/src/app/walk-and-talk/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { walkAndTalkServiceSchema, breadcrumbSchema, SchemaScript } from '@/lib/schema';
 
 export const metadata: Metadata = {
   title: 'Walk and Talk Consulting | Clarke Moyer',
@@ -21,6 +22,11 @@ const BOOK_60 = 'https://outlook.office.com/bookwithme/user/6a2b9209a2654d8e9f83
 export default function WalkAndTalkPage() {
   return (
     <>
+      <SchemaScript schema={walkAndTalkServiceSchema()} />
+      <SchemaScript schema={breadcrumbSchema([
+        { name: 'Home', url: '/' },
+        { name: 'Walk and Talk', url: '/walk-and-talk/' },
+      ])} />
       {/* ── Hero ── */}
       <section className="relative min-h-[52vh] bg-gray-900 flex items-center justify-center pt-36 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">
@@ -265,6 +271,12 @@ export default function WalkAndTalkPage() {
           >
             Inquire About Speaking →
           </a>
+          <p className="text-gray-500 text-sm mt-4">
+            Have questions first?{' '}
+            <Link href="/contact/" className="text-gray-700 underline hover:text-gray-900">
+              Contact Clarke →
+            </Link>
+          </p>
         </div>
       </section>
 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -41,6 +41,7 @@ const navLinks: NavLink[] = [
   { id: 'wgu-referral', href: '/wgu-referral-program', label: 'WGU REFERRAL PROGRAM' },
   { id: 'psu-arl-referral', href: '/psu-arl-referral-program', label: 'PSU-ARL REFERRAL PROGRAM' },
   { id: 'free-for-charity', href: '/free-for-charity', label: 'FREE FOR CHARITY' },
+  { id: 'contact', href: '/contact', label: 'CONTACT' },
 ];
 
 export default function Navigation() {

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -41,7 +41,7 @@ const navLinks: NavLink[] = [
   { id: 'wgu-referral', href: '/wgu-referral-program', label: 'WGU REFERRAL PROGRAM' },
   { id: 'psu-arl-referral', href: '/psu-arl-referral-program', label: 'PSU-ARL REFERRAL PROGRAM' },
   { id: 'free-for-charity', href: '/free-for-charity', label: 'FREE FOR CHARITY' },
-  { id: 'contact', href: '/contact', label: 'CONTACT' },
+  { id: 'contact', href: '/contact/', label: 'CONTACT' },
 ];
 
 export default function Navigation() {

--- a/src/lib/schema.tsx
+++ b/src/lib/schema.tsx
@@ -1,0 +1,85 @@
+// Base Person schema for Clarke Moyer — include on every page
+export function personSchema() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: 'Clarke Moyer',
+    url: 'https://clarkemoyer.com',
+    jobTitle: 'DoD R&D Program Manager & Technology Adoption Researcher',
+    description:
+      'Clarke Moyer is a DoD contractor at PSU-ARL, DBA candidate at Penn State Smeal College of Business, and founder of Free For Charity. Specializes in technology adoption barriers.',
+    sameAs: ['https://www.linkedin.com/in/clarkemoyer'],
+    alumniOf: [
+      { '@type': 'CollegeOrUniversity', name: 'Western Governors University' },
+      { '@type': 'CollegeOrUniversity', name: 'Penn State Smeal College of Business' },
+    ],
+    knowsAbout: [
+      'Technology Adoption',
+      'Cloud Architecture',
+      'Cybersecurity',
+      'Program Management',
+      'AI Strategy',
+    ],
+  }
+}
+
+// Walk and Talk consulting service schema
+export function walkAndTalkServiceSchema() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Service',
+    name: 'Walk and Talk Consulting',
+    description:
+      'Premium technology consulting with Clarke Moyer. No laptops, no slides — a focused conversation on a walk with an AI-generated summary delivered within 24 hours.',
+    url: 'https://clarkemoyer.com/walk-and-talk/',
+    provider: {
+      '@type': 'Person',
+      name: 'Clarke Moyer',
+      url: 'https://clarkemoyer.com',
+    },
+    serviceType: 'Technology Consulting',
+    areaServed: 'Worldwide',
+    offers: [
+      {
+        '@type': 'Offer',
+        name: '45-Minute Walk and Talk',
+        price: '562.50',
+        priceCurrency: 'USD',
+        availability: 'https://schema.org/InStock',
+        description: 'Available Monday–Friday, 1:30–2:30 PM EST',
+      },
+      {
+        '@type': 'Offer',
+        name: '1-Hour Walk and Talk',
+        price: '750.00',
+        priceCurrency: 'USD',
+        availability: 'https://schema.org/InStock',
+        description: 'Available Monday–Friday, 5:30–7:00 PM EST',
+      },
+    ],
+  }
+}
+
+// Breadcrumb schema — pass array of {name, url} items
+export function breadcrumbSchema(items: Array<{ name: string; url: string }>) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: `https://clarkemoyer.com${item.url}`,
+    })),
+  }
+}
+
+// Helper to render schema as <script> tag
+export function SchemaScript({ schema }: { schema: object }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  )
+}

--- a/src/lib/schema.tsx
+++ b/src/lib/schema.tsx
@@ -1,10 +1,12 @@
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://clarkemoyer.com';
+
 // Base Person schema for Clarke Moyer — include on every page
 export function personSchema() {
   return {
     '@context': 'https://schema.org',
     '@type': 'Person',
     name: 'Clarke Moyer',
-    url: 'https://clarkemoyer.com',
+    url: SITE_URL,
     jobTitle: 'DoD R&D Program Manager & Technology Adoption Researcher',
     description:
       'Clarke Moyer is a DoD contractor at PSU-ARL, DBA candidate at Penn State Smeal College of Business, and founder of Free For Charity. Specializes in technology adoption barriers.',
@@ -31,11 +33,11 @@ export function walkAndTalkServiceSchema() {
     name: 'Walk and Talk Consulting',
     description:
       'Premium technology consulting with Clarke Moyer. No laptops, no slides — a focused conversation on a walk with an AI-generated summary delivered within 24 hours.',
-    url: 'https://clarkemoyer.com/walk-and-talk/',
+    url: `${SITE_URL}/walk-and-talk/`,
     provider: {
       '@type': 'Person',
       name: 'Clarke Moyer',
-      url: 'https://clarkemoyer.com',
+      url: SITE_URL,
     },
     serviceType: 'Technology Consulting',
     areaServed: 'Worldwide',
@@ -69,7 +71,7 @@ export function breadcrumbSchema(items: Array<{ name: string; url: string }>) {
       '@type': 'ListItem',
       position: index + 1,
       name: item.name,
-      item: `https://clarkemoyer.com${item.url}`,
+      item: `${SITE_URL}${item.url}`,
     })),
   }
 }

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -56,3 +56,13 @@ test.describe('Smoke — page titles', () => {
     })
   }
 })
+
+test.describe('Custom 404 page', () => {
+  test('renders custom not-found page on unknown route', async ({ page }) => {
+    const response = await page.goto('/this-page-does-not-exist-at-all/')
+    // Next.js not-found returns 404 status
+    expect(response?.status()).toBe(404)
+    await expect(page.locator('h1')).toContainText('Page Not Found')
+    await expect(page.locator('text=Back to Home')).toBeVisible()
+  })
+})

--- a/tests/test.config.ts
+++ b/tests/test.config.ts
@@ -66,5 +66,7 @@ export const testConfig = {
     '/clarke-moyer-vcp5-dcv-passing-guide/',
     '/clarke-moyer-vcp6-cma-passing-guide/',
     '/clarke-moyer-vcp-am-passing-guide/',
+    '/contact/',
+    '/404',
   ],
 }


### PR DESCRIPTION
Closes #102, #103, #104 (partial — needs Formspree endpoint), #106 (partial)

## What's included
- Custom 404 not-found page with back links
- JSON-LD schema: Person (sitewide), Service (Walk and Talk), BreadcrumbList (all cert + recipe pages)
- Contact/inquiry form (/contact/) via Formspree — needs real endpoint from Clarke
- robots.txt verified + sitemap domain confirmed as clarkemoyer.com

## What Clarke needs to do
- Create Formspree account at formspree.io, create a form, replace PLACEHOLDER in contact page
- Provide Google Search Console verification token (separate issue #106)