### PR TITLE
fix: apex domain cutover — CNAME to clarkemoyer.com + /about → /who-i-am

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,1 @@
-staging.clarkemoyer.com
+clarkemoyer.com

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -173,7 +173,7 @@ export default async function Home() {
               <div className="p-6">
                 <h3 className="text-lg font-bold mb-3">Who I Am</h3>
                 <Link 
-                  href="/about"
+                  href="/who-i-am"
                   className="text-brand hover:text-brand-hover font-medium inline-flex items-center"
                 >
                   Learn More <ArrowRightIcon className="w-4 h-4 ml-1" />


### PR DESCRIPTION
## What changed
- **`public/CNAME`** updated from `staging.clarkemoyer.com` → `clarkemoyer.com` for apex domain deployment
- **`src/app/page.tsx`** fixed broken `/about` link on homepage → now correctly points to `/who-i-am`

## Why
DNS is now pointed at the apex domain (`clarkemoyer.com`). The old CNAME value would cause GitHub Pages to reject the custom domain. The `/about` route never existed — the actual page is `/who-i-am`.

## Testing
- Local build clean (53 pages, 0 errors)
- `out/CNAME` verified as `clarkemoyer.com`
- Homepage HTML verified `href="/who-i-am/"` in built output