### PR TITLE
fix: global nav in layout, /fun dead links, /about redirect, /who-i-am hero spacing

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function AboutRedirect() {
+  redirect('/who-i-am');
+}

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next'
-import Navigation from '@/components/Navigation'
 
 export const metadata: Metadata = {
   title: 'Cookie Policy',
@@ -11,7 +10,6 @@ const LAST_UPDATED = 'April 2026'
 export default function CookiePolicy() {
   return (
     <>
-      <Navigation />
       <div className="max-w-4xl mx-auto px-6 py-16 mt-20">
         <h1 className="text-3xl font-bold text-gray-900 mb-2">Cookie Policy</h1>
         <p className="text-sm text-gray-500 mb-8">

--- a/src/app/fun/page.tsx
+++ b/src/app/fun/page.tsx
@@ -101,12 +101,7 @@ export default async function FunPage() {
                 <p className="text-gray-700 mb-6">
                   I don&rsquo;t read many books but when I do I sometimes add them here.
                 </p>
-                <a
-                  href="#"
-                  className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-2 rounded-full transition-colors"
-                >
-                  Books &amp; Reading Homepage
-                </a>
+
               </div>
 
               {/* Travel & Events Card */}
@@ -115,12 +110,7 @@ export default async function FunPage() {
                 <p className="text-gray-700 mb-6">
                   We love to travel and do local things. I will try and list them here.
                 </p>
-                <a
-                  href="#"
-                  className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-2 rounded-full transition-colors"
-                >
-                  Travel &amp; Events homepage
-                </a>
+
               </div>
 
               {/* Speaking & Publishing Card */}
@@ -129,12 +119,7 @@ export default async function FunPage() {
                 <p className="text-gray-700 mb-6">
                   I am always looking for speaking and publishing opportunities. If I get them I post them here.
                 </p>
-                <a
-                  href="#"
-                  className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-2 rounded-full transition-colors"
-                >
-                  Speaking &amp; Publishing Homepage
-                </a>
+
               </div>
             </div>
           </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Script from "next/script";
 import "./globals.css";
 import CookieConsent from '@/components/cookie-consent';
+import Navigation from '@/components/Navigation';
 import { personSchema, SchemaScript } from '@/lib/schema';
 
 const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID || '';
@@ -70,6 +71,7 @@ export default function RootLayout({
         >
           Skip to main content
         </a>
+        <Navigation />
         <main id="main-content" tabIndex={-1} className="outline-none">{children}</main>
         <CookieConsent />
       </body>

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next'
-import Navigation from '@/components/Navigation'
 
 export const metadata: Metadata = {
   title: 'Privacy Policy',
@@ -11,7 +10,6 @@ const EFFECTIVE_DATE = 'April 27, 2026'
 export default function PrivacyPolicy() {
   return (
     <>
-      <Navigation />
       <div className="max-w-4xl mx-auto px-6 py-16 mt-20">
         <h1 className="text-3xl font-bold text-gray-900 mb-2">Privacy Policy</h1>
         <p className="text-sm text-gray-500 mb-8">

--- a/src/app/quotes/page.tsx
+++ b/src/app/quotes/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import Navigation from '@/components/Navigation';
 import { YoutubeEmbed } from './YoutubeEmbed';
 import Link from 'next/link';
 
@@ -96,8 +95,6 @@ const quotes: Quote[] = [
 export default function QuotesPage() {
   return (
     <>
-      <Navigation />
-
       {/* Hero Section */}
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
         <div className="text-center text-white max-w-4xl">

--- a/src/app/who-i-am/page.tsx
+++ b/src/app/who-i-am/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
 export default function WhoIAmPage() {
   return (
     <>
-      <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
+      <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center py-24 px-4">
         <div className="text-center text-white">
           <div className="text-sm mb-2">
             <Link href="/" className="hover:underline text-gray-300">Home</Link> / Who I Am


### PR DESCRIPTION
## Summary

Focused visual/UX fixes — zero content changes.

### Changes
- **Navigation in layout.tsx** — moves `<Navigation />` to root layout so every page has a header automatically; removes duplicate imports from quotes, cookie-policy, privacy-policy pages
- **/fun dead links** — removed the non-functional `href="#"` buttons on Books & Reading, Travel & Events, and Speaking & Publishing cards (no placeholder pages created)
- **/about redirect** — adds `src/app/about/page.tsx` that calls `redirect('/who-i-am')`; fixes the 404 on /about/
- **/who-i-am hero spacing** — replaces `pt-28 pb-16` with `py-24` to remove blank gap above hero text

### Build
✅ 58 static pages, 0 errors, 0 warnings

### No content was changed
All copy, text, intentional jokes, and page data untouched.