### PR TITLE
fix: home hero extends behind nav, nav links wrap on smaller viewports

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,7 +26,7 @@ export default async function Home() {
     <>
       {/* Hero Section with Family Photo Background */}
       <section 
-        className="relative min-h-screen bg-cover bg-center bg-no-repeat"
+        className="relative min-h-screen bg-cover bg-center bg-no-repeat -mt-40"
         style={{
           backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)), url('${basePath}/images/Grand-Canyon-2019-Family-Photo.jpg')`
         }}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -142,7 +142,7 @@ export default function Navigation() {
       {/* Main Navigation Menu (desktop) */}
       <div className="hidden lg:block bg-black/40 backdrop-blur-sm border-t border-white/20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-center items-center space-x-8 h-12">
+          <div className="flex justify-center items-center flex-wrap gap-x-4 gap-y-1 h-auto min-h-12 py-1">
             {navLinks.map((link) => (
               link.children ? (
                 <div


### PR DESCRIPTION
- Home page hero: add -mt-40 so the family photo fills behind the fixed nav (removes the gray nav-on-white-gap look)
- Nav link row: switch from space-x-8 fixed height to flex-wrap gap so all items are visible at 1280px instead of clipping off-screen