### PR TITLE
fix: improve home hero and desktop nav wrapping

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,7 +26,7 @@ export default async function Home() {
     <>
       {/* Hero Section with Family Photo Background */}
       <section
-        className="relative min-h-screen bg-cover bg-center bg-no-repeat"
+        className="relative -mt-40 min-h-screen bg-cover bg-center bg-no-repeat"
         style={{
           backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)), url('${basePath}/images/Grand-Canyon-2019-Family-Photo.jpg')`,
         }}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -176,7 +176,7 @@ export default function Navigation() {
       {/* Main Navigation Menu (desktop) */}
       <div className="hidden lg:block relative z-40 overflow-visible bg-black/40 backdrop-blur-sm border-t border-white/20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-center items-center space-x-8 h-12">
+          <div className="flex h-auto min-h-12 flex-wrap items-center justify-center gap-x-4 gap-y-1 py-1">
             {navLinks.map((link) =>
               link.children ? (
                 <div


### PR DESCRIPTION
## Summary
- Extends the homepage hero behind the transparent navigation overlay.
- Allows the desktop main navigation row to wrap with gaps instead of overflowing at narrower desktop widths.
- Reapplies the intended PR #118 behavior cleanly on top of current `main`.

## Validation
- `npm run lint` passed with existing warnings only.
- `npm test -- --runInBand` passed.
- `npm run build` passed.
- `npx playwright test tests/navigation.spec.ts tests/accessibility.spec.ts` passed: 235 passed.
- Independent review passed with no security or logic concerns.
- `npm run test:images` passed.
- `npm run test:e2e` passed: 670 passed, 2 skipped.

Supersedes #118.
