### PR TITLE
chore: align workflows to Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - run: npm run lint

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
         uses: actions/configure-pages@v6


### PR DESCRIPTION
## Summary
- Updates GitHub Actions Node setup from Node.js 22 to Node.js 24 across CI, deploy, Lighthouse, and Pages workflows.
- Reapplies the useful part of #91 cleanly on current `main` without the stale package and app changes from the old branch.

## Validation
- Confirmed local runtime: Node.js v24.15.0, npm 11.13.0.
- `git diff --check` passed.
- `npm run lint` passed with existing warnings only.
- `npm test -- --runInBand` passed.
- `npm run build` passed with Next.js 16.2.6 and 58 static routes.
- `npm run test:images` passed.

Supersedes #91.
