### PR TITLE
fix: override vulnerable nested postcss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9834,34 +9834,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -63,5 +63,8 @@
     "react"
   ],
   "author": "Clarke Moyer",
-  "license": "AGPL-3.0"
+  "license": "AGPL-3.0",
+  "overrides": {
+    "postcss": "$postcss"
+  }
 }


### PR DESCRIPTION
## Summary
- Adds an npm override so Next.js uses the already-patched `postcss` 8.5.14 instead of its nested 8.4.31 copy.
- Removes the remaining moderate npm audit findings without switching to an unstable Next.js canary or using `npm audit fix --force`.

## Validation
- `npm explain postcss` shows Next.js overridden from 8.4.31 to 8.5.14.
- `npm run lint` passed with existing warnings only.
- `npm test -- --runInBand` passed.
- `npm run build` passed with 58 static routes.
- `npm run test:images` passed.
- `npm run test:e2e` passed: 670 passed, 2 skipped.
- `npm audit --audit-level=moderate` passed: 0 vulnerabilities.
