### PR TITLE
docs: update post-cutover readiness status

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
-> **Status: Migration Complete — April 2026**
-> All phases complete. DNS cutover to clarkemoyer.com pending final Cloudflare configuration.
-> See `content/gap-analysis.md` for remaining pre-cutover checklist.
+> **Status: Migration Complete — Live on GitHub Pages (May 2026)**
+> The `clarkemoyer.com` DNS cutover is complete and the live site serves the Next.js/GitHub Pages build.
+> Remaining work is owner-side console polish documented in `README.md`, `docs/DEPLOYMENT.md`, and `content/gap-analysis.md`.
 
 # WordPress to Next.js Migration Methodology
 
@@ -88,7 +88,7 @@ This document outlines the comprehensive methodology used to migrate clarkemoyer
 - **Special functionality**: Referral programs, certification guides
 
 #### Technology Stack Selection
-- **Framework**: Next.js 15 (latest stable)
+- **Framework**: Next.js 16
 - **Language**: TypeScript for type safety
 - **Styling**: Tailwind CSS for utility-first design
 - **Content**: Markdown with frontmatter

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # clarkemoyer.com
 
-Personal website for Clarke Moyer — built with Next.js, deployed to GitHub Pages via Cloudflare.
+Personal website for Clarke Moyer — built with Next.js and deployed to GitHub Pages.
 
-- **Staging:** https://staging.clarkemoyer.com
-- **Production:** https://clarkemoyer.com (post DNS cutover)
+- **Production:** https://clarkemoyer.com — live on the Next.js/GitHub Pages build
 - **Repo:** https://github.com/clarkemoyer/clarkemoyer.com
+- **Status:** migration/cutover code work is complete; remaining items are owner-side console polish
 
 ---
 
 ## Technology Stack
 
-- **Framework:** Next.js 15 + React 19 + TypeScript
+- **Framework:** Next.js 16 + React 19 + TypeScript
 - **Styling:** Tailwind CSS
 - **Deployment:** GitHub Actions → static export (`out/`) → GitHub Pages
-- **DNS/CDN:** Cloudflare (proxy, security headers, 301 redirects)
+- **DNS/CDN:** GitHub Pages direct serving today; Cloudflare may be re-enabled for edge headers/redirects
 - **Analytics:** Google Tag Manager (`GTM-5JL6TDQW`) + Google Analytics 4 (`G-C2Q1HC0GVQ`)
 - **Testing:** Jest + Playwright + Lighthouse CI
 
@@ -23,12 +23,12 @@ Personal website for Clarke Moyer — built with Next.js, deployed to GitHub Pag
 
 These are **public tracking IDs** — not secrets. They are hardcoded in `.github/workflows/deploy.yml`.
 
-| Variable | Value | Purpose |
-|---|---|---|
-| `NEXT_PUBLIC_GA_MEASUREMENT_ID` | `G-C2Q1HC0GVQ` | Google Analytics 4 |
-| `NEXT_PUBLIC_GTM_ID` | `GTM-5JL6TDQW` | Google Tag Manager |
-| `NEXT_PUBLIC_SITE_URL` | `https://clarkemoyer.com` | Canonical URL / metadataBase |
-| `USE_BASE_PATH` | `false` | GitHub Pages basePath (false = custom domain) |
+| Variable                        | Value                     | Purpose                                       |
+| ------------------------------- | ------------------------- | --------------------------------------------- |
+| `NEXT_PUBLIC_GA_MEASUREMENT_ID` | `G-C2Q1HC0GVQ`            | Google Analytics 4                            |
+| `NEXT_PUBLIC_GTM_ID`            | `GTM-5JL6TDQW`            | Google Tag Manager                            |
+| `NEXT_PUBLIC_SITE_URL`          | `https://clarkemoyer.com` | Canonical URL / metadataBase                  |
+| `USE_BASE_PATH`                 | `false`                   | GitHub Pages basePath (false = custom domain) |
 
 ### google-prod Environment (Pending)
 
@@ -118,16 +118,19 @@ clarkemoyer.com/
 ## Analytics & Tracking
 
 ### Google Tag Manager (`GTM-5JL6TDQW`)
+
 Loaded in `layout.tsx` via `next/script afterInteractive`. Manages all tracking tags.
 Add new tags via the GTM UI — no code deploys required.
 
 ### Google Analytics 4 (`G-C2Q1HC0GVQ`)
+
 - Property: `362129069` | Account: `17425922`
 - Loaded **only after user grants analytics consent** via the cookie banner
 - `anonymize_ip: true` set by default
 - Recommended: also configure a GA4 tag in GTM with a consent trigger
 
 ### Cookie Consent
+
 Bottom banner with Accept All / Decline All / Customize.
 Stores preferences in `localStorage` + `document.cookie`.
 Fires `consent_update` dataLayer events for GTM consent mode.
@@ -135,13 +138,21 @@ Footer "Cookie Preferences" button reopens the modal from any page.
 
 ---
 
-## Cloudflare Setup (Pre-Cutover)
+## Owner-Side Post-Cutover Polish
 
-See `.github/copilot-instructions.md` for the full Cloudflare checklist including:
-- Bulk Redirects (301s for old WordPress slugs)
-- Response header Transform Rules (security headers)
-- SSL/TLS settings
-- DNS cutover records
+The live site is already serving from GitHub Pages at `https://clarkemoyer.com`. Remaining items require owner access to GitHub, Cloudflare, or Google Search Console:
+
+- Confirm **Enforce HTTPS** in GitHub Pages settings. HTTPS works, but the Pages API currently returns `enforce_https: null`.
+- Decide whether to keep direct GitHub Pages serving or place Cloudflare proxy back in front.
+- If using Cloudflare, add response-header Transform Rules / Workers for security headers:
+  - `Strict-Transport-Security`
+  - `Content-Security-Policy`
+  - `X-Frame-Options` or equivalent frame policy
+  - `X-Content-Type-Options`
+  - `Referrer-Policy`
+  - `Permissions-Policy`
+- If using Cloudflare, add edge 301 redirects from long alias URLs to short canonical URLs for cleaner SEO.
+- Submit or refresh `https://clarkemoyer.com/sitemap.xml` in Google Search Console.
 
 ---
 
@@ -150,14 +161,14 @@ See `.github/copilot-instructions.md` for the full Cloudflare checklist includin
 The original short WordPress URLs are canonical for readability when shared verbally.
 Longer descriptive routes remain available as redirect aliases for backlinks/bookmarks.
 
-| Canonical URL | Redirect alias |
-|---|---|
-| `/certification/` | `/certification-guides/` |
-| `/charity/` | `/free-for-charity/` |
-| `/education/` | `/western-governors-university-bs-it/` |
-| `/resume/` | `/it-project-management-resume-of-clarke-moyer/` |
-| `/psu-arl-referral/` | `/psu-arl-referral-program/` |
-| `/wgu-referral/` | `/wgu-referral-program/` |
+| Canonical URL        | Redirect alias                                   |
+| -------------------- | ------------------------------------------------ |
+| `/certification/`    | `/certification-guides/`                         |
+| `/charity/`          | `/free-for-charity/`                             |
+| `/education/`        | `/western-governors-university-bs-it/`           |
+| `/resume/`           | `/it-project-management-resume-of-clarke-moyer/` |
+| `/psu-arl-referral/` | `/psu-arl-referral-program/`                     |
+| `/wgu-referral/`     | `/wgu-referral-program/`                         |
 
 ---
 
@@ -170,6 +181,7 @@ npm run build && npm run test:e2e   # E2E tests (Playwright)
 ```
 
 Lighthouse CI runs automatically post-deploy. Thresholds:
+
 - Performance ≥ 55%
 - Accessibility ≥ 90%
 - Best Practices ≥ 65%

--- a/content/README.md
+++ b/content/README.md
@@ -22,8 +22,8 @@ Pages that still use `sections/` files: resume, family, fun, and a few others �
 
 ```markdown
 ---
-title: "Page Title"
-description: "Meta description for SEO"
+title: 'Page Title'
+description: 'Meta description for SEO'
 ---
 
 Markdown content here...
@@ -36,6 +36,7 @@ Markdown content here...
 Complete preservation of the original WordPress site content, retained for reference. This directory is **not used at runtime** — the Next.js build does not read from it.
 
 Contents:
+
 - `pages/` — original WordPress page HTML files
 - `uploads/` — WordPress media files organized by year (2012, 2020, 2021, 2023)
 - `extracted-content/` — Markdown versions converted from WordPress HTML
@@ -47,4 +48,4 @@ These files serve as a historical archive and fallback reference if content ques
 
 ## `content/gap-analysis.md`
 
-Tracks migration parity between WordPress and Next.js. As of April 2026, all original gap analysis items from Issue #41 have been resolved. See the file for current pre-cutover checklist.
+Tracks migration parity between WordPress and Next.js. As of May 2026, the live cutover is complete; remaining notes are owner-side console polish.

--- a/content/gap-analysis.md
+++ b/content/gap-analysis.md
@@ -3,9 +3,13 @@
 All items from the original gap analysis (Issue #41) have been addressed.
 See the closed issue for history: https://github.com/clarkemoyer/clarkemoyer.com/issues/41
 
-## Current Status (April 2026)
-- All 14 WordPress URLs live at correct slugs ✅
-- Old slugs have client-side redirects + Cloudflare 301s pending cutover ✅
+## Current Status (May 2026)
+
+- Live `https://clarkemoyer.com` serves the Next.js/GitHub Pages build ✅
+- GitHub Pages custom domain is `clarkemoyer.com` ✅
+- DNS resolves to GitHub Pages IPv4/IPv6 addresses ✅
+- All original short WordPress URLs are canonical and live ✅
+- Longer descriptive URLs remain available as in-app aliases ✅
 - Per-page SEO metadata on all pages ✅
 - sitemap.xml and robots.txt present ✅
 - Cookie consent system with privacy/cookie policy pages ✅
@@ -13,14 +17,18 @@ See the closed issue for history: https://github.com/clarkemoyer/clarkemoyer.com
 - Google Tag Manager (GTM-5JL6TDQW) in layout ✅
 - Full test suite: Jest + Playwright + Lighthouse CI ✅
 
-## Remaining Before DNS Cutover
-- Verify Cloudflare DNS points apex/www to GitHub Pages after staging approval
-- Add Cloudflare security response headers
-- Create google-prod GitHub environment (repo owner only)
-- Submit sitemap to Google Search Console after cutover
+## Remaining Owner-Side Polish
+
+- Confirm GitHub Pages **Enforce HTTPS** in repo settings. HTTPS works, but the Pages API reports `enforce_https: null`.
+- Decide whether to keep direct GitHub Pages serving or place Cloudflare proxy back in front.
+- If using Cloudflare, add security response headers at the edge.
+- If using Cloudflare, add edge 301 redirects from long alias URLs to the short canonical URLs for stronger SEO.
+- Submit/refresh `https://clarkemoyer.com/sitemap.xml` in Google Search Console after cutover.
 
 ## Canonical URL Decision (May 2026)
+
 Clarke requested the original short WordPress URLs remain canonical for phone readability:
+
 - `/certification/`
 - `/charity/`
 - `/education/`

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -2,10 +2,9 @@
 
 ## Current Configuration
 
-- **Staging URL:** `https://staging.clarkemoyer.com` ✅ Live
-- **Production URL:** `https://clarkemoyer.com` — pending DNS cutover
-- **Hosting:** GitHub Pages (static export via `next export`)
-- **CDN/Proxy:** Cloudflare
+- **Production URL:** `https://clarkemoyer.com` — live on GitHub Pages
+- **Hosting:** GitHub Pages (static export via `next build`)
+- **CDN/Proxy:** GitHub Pages direct serving today; Cloudflare may be re-enabled for edge headers/redirects
 
 ---
 
@@ -15,7 +14,7 @@ The site supports two modes depending on where it's served from.
 
 ### 1. Custom Domain Mode (Current)
 
-Used when serving from a custom domain (`staging.clarkemoyer.com` or `clarkemoyer.com`).
+Used when serving from the custom production domain (`clarkemoyer.com`).
 
 - `USE_BASE_PATH=false` (or unset)
 - Asset paths are root-relative: `/images/photo.jpg`
@@ -35,12 +34,12 @@ Used when serving from `https://clarkemoyer.github.io/clarkemoyer.com/`.
 
 These four variables are used at build time. They are set as plain `env:` entries in the workflow (not GitHub secrets) because they are public-facing tracking IDs.
 
-| Variable | Value | Purpose |
-|---|---|---|
-| `NEXT_PUBLIC_GA_MEASUREMENT_ID` | `G-C2Q1HC0GVQ` | Google Analytics 4 |
-| `NEXT_PUBLIC_GTM_ID` | `GTM-5JL6TDQW` | Google Tag Manager |
-| `NEXT_PUBLIC_SITE_URL` | `https://clarkemoyer.com` | Canonical URL / sitemap |
-| `USE_BASE_PATH` | `false` | Deployment mode (see above) |
+| Variable                        | Value                     | Purpose                     |
+| ------------------------------- | ------------------------- | --------------------------- |
+| `NEXT_PUBLIC_GA_MEASUREMENT_ID` | `G-C2Q1HC0GVQ`            | Google Analytics 4          |
+| `NEXT_PUBLIC_GTM_ID`            | `GTM-5JL6TDQW`            | Google Tag Manager          |
+| `NEXT_PUBLIC_SITE_URL`          | `https://clarkemoyer.com` | Canonical URL / sitemap     |
+| `USE_BASE_PATH`                 | `false`                   | Deployment mode (see above) |
 
 ### google-prod GitHub Environment
 
@@ -57,8 +56,9 @@ Collaborators cannot create environments on personal repos. Once created, the fo
 Triggers on every push to `main` (also supports `workflow_dispatch`).
 
 **Steps:**
+
 1. Checkout source
-2. Setup Node.js 20 with npm cache
+2. Setup Node.js 24 with npm cache
 3. `npm ci` — install dependencies
 4. `npm run build` — Next.js static export to `out/`; env vars injected here
 5. `touch ./out/.nojekyll` — prevents Jekyll processing on GitHub Pages
@@ -86,7 +86,7 @@ npx serve out/
 
 ## DNS Records for GitHub Pages
 
-When cutting over production, point `clarkemoyer.com` to GitHub Pages:
+Production currently resolves to GitHub Pages. Expected records are:
 
 ```
 # Apex domain (A records)
@@ -97,23 +97,19 @@ A   185.199.111.153
 
 # www subdomain
 CNAME   www   clarkemoyer.github.io
-
-# staging (already live)
-CNAME   staging   clarkemoyer.github.io
 ```
 
 ---
 
-## Cloudflare Pre-Cutover Checklist
+## Owner-Side Post-Cutover Checklist
 
-Before switching DNS to point `clarkemoyer.com` at GitHub Pages:
+The live custom domain is already serving the GitHub Pages build. Remaining console tasks:
 
-- [ ] **Bulk Redirects** — add 301 rules for all old WordPress slugs (see `content/gap-analysis.md`)
-- [ ] **Security response headers** — add `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy` via Transform Rules or Workers
-- [ ] **SSL/TLS mode** — set to **Full (strict)**
-- [ ] **HSTS** — enable via SSL/TLS → Edge Certificates → HTTP Strict Transport Security
-- [ ] **DNS records** — add A/CNAME records above pointing to GitHub Pages IPs
-- [ ] **Pause Cloudflare proxy** during GitHub Pages SSL provisioning if needed, then re-enable
+- [ ] **GitHub Pages HTTPS** — confirm Enforce HTTPS is enabled. The Pages API currently reports `enforce_https: null` even though HTTPS works.
+- [ ] **Cloudflare posture** — decide whether to keep direct GitHub Pages serving or re-enable Cloudflare proxy.
+- [ ] **Security response headers** — if Cloudflare is used, add `Strict-Transport-Security`, `Content-Security-Policy`, `X-Frame-Options` or equivalent, `X-Content-Type-Options`, `Referrer-Policy`, and `Permissions-Policy` via Transform Rules or Workers.
+- [ ] **Edge redirects** — if Cloudflare is used, add 301 redirects from long alias URLs to the short canonical URLs for cleaner SEO.
+- [ ] **Search Console** — submit/refresh `https://clarkemoyer.com/sitemap.xml` and inspect/request indexing for key canonical pages.
 
 ---
 

--- a/next.config.js
+++ b/next.config.js
@@ -4,16 +4,14 @@ const nextConfig = {
   trailingSlash: true,
   images: {
     unoptimized: true,
-    remotePatterns: [
-      { protocol: 'https', hostname: 'img.youtube.com' },
-    ],
+    remotePatterns: [{ protocol: 'https', hostname: 'img.youtube.com' }],
   },
   // GitHub Pages serves from a subdirectory for project pages
   // For https://clarkemoyer.github.io/clarkemoyer.com/ we need basePath: '/clarkemoyer.com'
-  // For custom domains (e.g., staging.clarkemoyer.com) we need NO basePath
+  // For custom domains (e.g., clarkemoyer.com) we need NO basePath
   // Use USE_BASE_PATH environment variable to control this explicitly
   basePath: process.env.USE_BASE_PATH === 'true' ? '/clarkemoyer.com' : '',
   assetPrefix: process.env.USE_BASE_PATH === 'true' ? '/clarkemoyer.com' : '',
-};
+}
 
-export default nextConfig;
+export default nextConfig


### PR DESCRIPTION
## Summary
- Updates README/deployment/migration docs from pre-cutover/staging language to current live GitHub Pages status.
- Documents remaining owner-side console polish: GitHub Pages Enforce HTTPS confirmation, Cloudflare posture/headers/edge redirects, and Search Console sitemap refresh.
- Refreshes stale references to Next.js 15, Node.js 20 workflows, staging DNS, and pre-cutover checklists.

## Validation
- npm run lint (passes with existing warnings only)
- npm test -- --runInBand
- npm run build
- npm audit --audit-level=moderate
- Live smoke checks for production paths returned 200, Next.js static assets present, and no WordPress markers
- GitHub Pages API confirms cname `clarkemoyer.com` with approved certificate

Closes #40
