### PR TITLE
fix: harden canonical alias redirect pages

### DIFF
--- a/docs/cloudflare-canonical-redirects.csv
+++ b/docs/cloudflare-canonical-redirects.csv
@@ -1,0 +1,8 @@
+source_url,target_url,status_code,preserve_query_string
+https://clarkemoyer.com/about/,https://clarkemoyer.com/who-i-am/,301,true
+https://clarkemoyer.com/certification-guides/,https://clarkemoyer.com/certification/,301,true
+https://clarkemoyer.com/free-for-charity/,https://clarkemoyer.com/charity/,301,true
+https://clarkemoyer.com/western-governors-university-bs-it/,https://clarkemoyer.com/education/,301,true
+https://clarkemoyer.com/it-project-management-resume-of-clarke-moyer/,https://clarkemoyer.com/resume/,301,true
+https://clarkemoyer.com/psu-arl-referral-program/,https://clarkemoyer.com/psu-arl-referral/,301,true
+https://clarkemoyer.com/wgu-referral-program/,https://clarkemoyer.com/wgu-referral/,301,true

--- a/docs/cloudflare-canonical-redirects.md
+++ b/docs/cloudflare-canonical-redirects.md
@@ -1,0 +1,40 @@
+# Cloudflare canonical redirect rules
+
+Use these edge redirects if/when Cloudflare is placed in front of `clarkemoyer.com` again. The Next.js static export keeps these aliases usable with canonical/noindex metadata and browser-side replacement, but GitHub Pages cannot emit true HTTP 301/308 redirects for static-exported app routes. Cloudflare Bulk Redirects or Redirect Rules are the correct place for permanent SEO consolidation at the HTTP edge.
+
+## Canonical URL decision
+
+The original short WordPress-era URLs are canonical because they are easier to say, share, and remember.
+
+## Redirect map
+
+| Source alias | Canonical target |
+| --- | --- |
+| `https://clarkemoyer.com/about/` | `https://clarkemoyer.com/who-i-am/` |
+| `https://clarkemoyer.com/certification-guides/` | `https://clarkemoyer.com/certification/` |
+| `https://clarkemoyer.com/free-for-charity/` | `https://clarkemoyer.com/charity/` |
+| `https://clarkemoyer.com/western-governors-university-bs-it/` | `https://clarkemoyer.com/education/` |
+| `https://clarkemoyer.com/it-project-management-resume-of-clarke-moyer/` | `https://clarkemoyer.com/resume/` |
+| `https://clarkemoyer.com/psu-arl-referral-program/` | `https://clarkemoyer.com/psu-arl-referral/` |
+| `https://clarkemoyer.com/wgu-referral-program/` | `https://clarkemoyer.com/wgu-referral/` |
+
+## Recommended Cloudflare behavior
+
+- Status code: `301` or `308` permanent redirect.
+- Preserve query string: yes.
+- Matching: exact path, trailing slash variant included if Cloudflare does not normalize it.
+- Scope: `clarkemoyer.com` and `www.clarkemoyer.com` if both are proxied through Cloudflare.
+- Do not redirect canonical pages back to aliases.
+
+## Bulk Redirect CSV
+
+```csv
+source_url,target_url,status_code,preserve_query_string
+https://clarkemoyer.com/about/,https://clarkemoyer.com/who-i-am/,301,true
+https://clarkemoyer.com/certification-guides/,https://clarkemoyer.com/certification/,301,true
+https://clarkemoyer.com/free-for-charity/,https://clarkemoyer.com/charity/,301,true
+https://clarkemoyer.com/western-governors-university-bs-it/,https://clarkemoyer.com/education/,301,true
+https://clarkemoyer.com/it-project-management-resume-of-clarke-moyer/,https://clarkemoyer.com/resume/,301,true
+https://clarkemoyer.com/psu-arl-referral-program/,https://clarkemoyer.com/psu-arl-referral/,301,true
+https://clarkemoyer.com/wgu-referral-program/,https://clarkemoyer.com/wgu-referral/,301,true
+```

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,5 +1,12 @@
-import { redirect } from 'next/navigation';
+import type { Metadata } from 'next'
+import SeoAliasRedirect from '@/components/SeoAliasRedirect'
+
+export const metadata: Metadata = {
+  title: 'About moved to Who I Am',
+  robots: { index: false, follow: true },
+  alternates: { canonical: '/who-i-am/' },
+}
 
 export default function AboutRedirect() {
-  redirect('/who-i-am');
+  return <SeoAliasRedirect destination="/who-i-am/" destinationLabel="/who-i-am/" />
 }

--- a/src/app/certification-guides/page.tsx
+++ b/src/app/certification-guides/page.tsx
@@ -1,4 +1,12 @@
-import { redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+import SeoAliasRedirect from '@/components/SeoAliasRedirect'
+
+export const metadata: Metadata = {
+  title: 'Certification Guides moved to Certification',
+  robots: { index: false, follow: true },
+  alternates: { canonical: '/certification/' },
+}
+
 export default function CertificationGuidesPage() {
-  redirect('/certification')
+  return <SeoAliasRedirect destination="/certification/" destinationLabel="/certification/" />
 }

--- a/src/app/free-for-charity/page.tsx
+++ b/src/app/free-for-charity/page.tsx
@@ -1,4 +1,12 @@
-import { redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+import SeoAliasRedirect from '@/components/SeoAliasRedirect'
+
+export const metadata: Metadata = {
+  title: 'Free For Charity moved to Charity',
+  robots: { index: false, follow: true },
+  alternates: { canonical: '/charity/' },
+}
+
 export default function FreeForCharityPage() {
-  redirect('/charity')
+  return <SeoAliasRedirect destination="/charity/" destinationLabel="/charity/" />
 }

--- a/src/app/it-project-management-resume-of-clarke-moyer/page.tsx
+++ b/src/app/it-project-management-resume-of-clarke-moyer/page.tsx
@@ -1,4 +1,12 @@
-import { redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+import SeoAliasRedirect from '@/components/SeoAliasRedirect'
+
+export const metadata: Metadata = {
+  title: 'IT Project Management Resume moved to Resume',
+  robots: { index: false, follow: true },
+  alternates: { canonical: '/resume/' },
+}
+
 export default function ItProjectManagementResumeOfClarkeMoyerPage() {
-  redirect('/resume')
+  return <SeoAliasRedirect destination="/resume/" destinationLabel="/resume/" />
 }

--- a/src/app/psu-arl-referral-program/page.tsx
+++ b/src/app/psu-arl-referral-program/page.tsx
@@ -1,4 +1,12 @@
-import { redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+import SeoAliasRedirect from '@/components/SeoAliasRedirect'
+
+export const metadata: Metadata = {
+  title: 'PSU-ARL Referral Program moved to PSU-ARL Referral',
+  robots: { index: false, follow: true },
+  alternates: { canonical: '/psu-arl-referral/' },
+}
+
 export default function PsuArlReferralProgramPage() {
-  redirect('/psu-arl-referral')
+  return <SeoAliasRedirect destination="/psu-arl-referral/" destinationLabel="/psu-arl-referral/" />
 }

--- a/src/app/western-governors-university-bs-it/page.tsx
+++ b/src/app/western-governors-university-bs-it/page.tsx
@@ -1,4 +1,12 @@
-import { redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+import SeoAliasRedirect from '@/components/SeoAliasRedirect'
+
+export const metadata: Metadata = {
+  title: 'Western Governors University BS-IT moved to Education',
+  robots: { index: false, follow: true },
+  alternates: { canonical: '/education/' },
+}
+
 export default function WesternGovernorsUniversityBsItPage() {
-  redirect('/education')
+  return <SeoAliasRedirect destination="/education/" destinationLabel="/education/" />
 }

--- a/src/app/wgu-referral-program/page.tsx
+++ b/src/app/wgu-referral-program/page.tsx
@@ -1,4 +1,12 @@
-import { redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+import SeoAliasRedirect from '@/components/SeoAliasRedirect'
+
+export const metadata: Metadata = {
+  title: 'WGU Referral Program moved to WGU Referral',
+  robots: { index: false, follow: true },
+  alternates: { canonical: '/wgu-referral/' },
+}
+
 export default function WguReferralProgramPage() {
-  redirect('/wgu-referral')
+  return <SeoAliasRedirect destination="/wgu-referral/" destinationLabel="/wgu-referral/" />
 }

--- a/src/components/SeoAliasRedirect.tsx
+++ b/src/components/SeoAliasRedirect.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect } from 'react'
+import Link from 'next/link'
+
+type SeoAliasRedirectProps = {
+  destination: string
+  destinationLabel: string
+}
+
+export default function SeoAliasRedirect({ destination, destinationLabel }: SeoAliasRedirectProps) {
+  useEffect(() => {
+    window.location.replace(destination)
+  }, [destination])
+
+  return (
+    <main className="min-h-screen bg-slate-950 text-white flex items-center justify-center px-6 py-24">
+      <section className="max-w-xl text-center space-y-6">
+        <p className="uppercase tracking-[0.35em] text-sm text-blue-300">Page moved</p>
+        <h1 className="text-3xl md:text-4xl font-bold">This page now lives at {destinationLabel}.</h1>
+        <p className="text-slate-300">
+          You should be redirected automatically. If not, use the canonical link below.
+        </p>
+        <Link
+          href={destination}
+          className="inline-flex rounded-full bg-blue-500 px-6 py-3 font-semibold text-white transition hover:bg-blue-400"
+        >
+          Go to {destinationLabel}
+        </Link>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- Replaces static-export alias pages that used `redirect()` with explicit SEO-safe alias landing pages.
- Adds `noindex, follow` and canonical metadata pointing each alias to the short canonical URL.
- Adds a reusable `SeoAliasRedirect` client component that performs browser-side replacement while still rendering a crawlable fallback link.
- Documents the matching Cloudflare Bulk Redirect CSV for true HTTP 301 edge redirects when Cloudflare is in front of the site.

## Redirect/canonical map
- `/about/` -> `/who-i-am/`
- `/certification-guides/` -> `/certification/`
- `/free-for-charity/` -> `/charity/`
- `/western-governors-university-bs-it/` -> `/education/`
- `/it-project-management-resume-of-clarke-moyer/` -> `/resume/`
- `/psu-arl-referral-program/` -> `/psu-arl-referral/`
- `/wgu-referral-program/` -> `/wgu-referral/`

## Validation
- `npm run lint` passes with existing warnings only.
- `npm test -- --runInBand` passes: 3 suites, 16 tests.
- `npm run build` passes: 58 static routes generated.
- Verified generated alias pages are not `__next_error__` pages and contain canonical/noindex/follow metadata plus target links.

## Note
GitHub Pages static export cannot emit true HTTP 301/308 redirects from app routes. The repo now has the safest static-page behavior available in-code, plus `docs/cloudflare-canonical-redirects.csv` for Cloudflare edge redirects when Cloudflare credentials/configuration are available.
