### PR TITLE
fix: polish mobile cutover visuals

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -72,7 +72,7 @@ export default function RootLayout({
           Skip to main content
         </a>
         <Navigation />
-        <main id="main-content" tabIndex={-1} className="outline-none pt-40">{children}</main>
+        <main id="main-content" tabIndex={-1} className="outline-none pt-16 lg:pt-40">{children}</main>
         <CookieConsent />
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,7 +26,7 @@ export default async function Home() {
     <>
       {/* Hero Section with Family Photo Background */}
       <section
-        className="relative -mt-40 min-h-screen bg-cover bg-center bg-no-repeat"
+        className="relative -mt-16 min-h-screen bg-cover bg-center bg-no-repeat lg:-mt-40"
         style={{
           backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)), url('${basePath}/images/Grand-Canyon-2019-Family-Photo.jpg')`,
         }}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -91,14 +91,14 @@ export default function Navigation() {
                     d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
                   />
                 </svg>
-                <span className="ml-2 text-sm font-medium tracking-wider">SEARCH</span>
+                <span className="ml-2 hidden text-sm font-medium tracking-wider sm:inline">SEARCH</span>
               </a>
             </div>
 
             {/* Center - Brand */}
             <div className="text-center">
               <Link href="/" className="text-white hover:text-gray-200 transition-colors">
-                <span className="text-xl font-bold tracking-widest leading-tight">
+                <span className="text-lg font-bold tracking-wider leading-tight sm:text-xl sm:tracking-widest">
                   CLARKE MOYER
                 </span>
               </Link>
@@ -131,7 +131,7 @@ export default function Navigation() {
                     />
                   </svg>
                 )}
-                <span className="ml-2 text-sm font-medium tracking-wider">MENU</span>
+                <span className="ml-2 hidden text-sm font-medium tracking-wider sm:inline">MENU</span>
               </button>
             </div>
           </div>

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -207,20 +207,20 @@ export default function CookieConsent() {
 
   const banner = (
     <div className="fixed bottom-0 left-0 right-0 z-50 bg-white border-t-2 border-gray-200 shadow-2xl" role="region" aria-label="Cookie consent notice">
-      <div className="max-w-7xl mx-auto p-4 sm:p-6">
-        <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
+      <div className="max-w-7xl mx-auto p-3 sm:p-6">
+        <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-3 sm:gap-4">
           <div className="flex-1">
-            <h3 className="text-lg font-bold text-gray-900 mb-2">We Value Your Privacy</h3>
-            <p className="text-sm text-gray-600 mb-3">We use cookies to improve your experience and analyze traffic. You can accept all, decline non-essential cookies, or customize your preferences.</p>
+            <h3 className="text-base font-bold text-gray-900 mb-1 sm:text-lg sm:mb-2">We Value Your Privacy</h3>
+            <p className="text-xs text-gray-600 mb-2 sm:text-sm sm:mb-3">We use cookies to improve your experience and analyze traffic. You can accept all, decline non-essential cookies, or customize your preferences.</p>
             <div className="flex items-center gap-4 text-xs text-gray-500">
               <Link href="/privacy-policy" className="text-blue-600 hover:underline">Privacy Policy</Link>
               <Link href="/cookie-policy" className="text-blue-600 hover:underline">Cookie Policy</Link>
             </div>
           </div>
-          <div className="flex flex-col sm:flex-row gap-2 w-full md:w-auto">
-            <button onClick={handleDeclineAll} className="px-6 py-2.5 bg-gray-200 text-gray-700 rounded-lg font-semibold hover:bg-gray-300 transition-colors text-sm whitespace-nowrap">Decline All</button>
-            <button onClick={handleCustomize} className="px-6 py-2.5 bg-gray-200 text-gray-700 rounded-lg font-semibold hover:bg-gray-300 transition-colors text-sm whitespace-nowrap">Customize</button>
-            <button onClick={handleAcceptAll} className="px-6 py-2.5 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition-colors text-sm whitespace-nowrap">Accept All</button>
+          <div className="grid w-full grid-cols-3 gap-2 md:flex md:w-auto">
+            <button onClick={handleDeclineAll} className="px-3 py-2 bg-gray-200 text-gray-700 rounded-lg font-semibold hover:bg-gray-300 transition-colors text-xs whitespace-nowrap sm:px-6 sm:py-2.5 sm:text-sm">Decline All</button>
+            <button onClick={handleCustomize} className="px-3 py-2 bg-gray-200 text-gray-700 rounded-lg font-semibold hover:bg-gray-300 transition-colors text-xs whitespace-nowrap sm:px-6 sm:py-2.5 sm:text-sm">Customize</button>
+            <button onClick={handleAcceptAll} className="px-3 py-2 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition-colors text-xs whitespace-nowrap sm:px-6 sm:py-2.5 sm:text-sm">Accept All</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Remove the excessive mobile gap between the fixed header and interior page heroes by making the global main offset responsive.
- Keep the homepage hero aligned with the responsive offset so desktop remains unchanged while mobile starts cleanly under the nav.
- Reduce mobile header crowding by hiding SEARCH/MENU labels below the small breakpoint and tightening the brand wordmark.
- Compact the cookie consent banner on mobile with smaller spacing and a three-button row.

## Visual QA
- Before: 390px mobile screenshots showed a large white gap under the header on interior pages, a crowded header, and an oversized stacked cookie banner.
- After: local Playwright screenshots at 390px confirm the hero begins directly under the header, the mobile header has balanced icon/brand spacing, and the cookie banner is materially shorter.
- Desktop 1440px screenshot checked for nav/top-spacing regressions; no wrapping or clipping was visible.

## Test plan
- `npm run lint`
- `npm test -- --runInBand`
- `npm run build`
- `npm run test:images`
- `npm run test:e2e -- --project=chromium`
- Local Playwright visual smoke at 390px mobile and 1440px desktop for `/`, `/certification/`, and `/who-i-am/`
