### PR TITLE
fix: make walk and talk primary CTA

### DIFF
--- a/__tests__/pages/homepage-visual-polish.test.tsx
+++ b/__tests__/pages/homepage-visual-polish.test.tsx
@@ -8,12 +8,13 @@ describe('Clarke Moyer homepage visual polish', () => {
     expect(
       screen.getByText(/Projects, referrals, certification guides, and community initiatives/i)
     ).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /Connect on LinkedIn/i })).toHaveClass('bg-white')
+    expect(screen.getByRole('link', { name: /Book a Walk and Talk/i })).toHaveClass('bg-white')
+    expect(screen.getByRole('link', { name: /Connect on LinkedIn/i })).toHaveClass('border')
+    expect(screen.getByRole('link', { name: /View Projects/i })).toHaveClass('border')
     expect(screen.getByRole('link', { name: /View Projects/i })).toHaveAttribute(
       'href',
       '#projects'
     )
-    expect(screen.getByRole('link', { name: /Book a Walk and Talk/i })).toHaveClass('border')
   })
 
   it('renders standardized project cards with specific CTA labels and no generic learn-more copy', async () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -103,26 +103,26 @@ export default async function Home() {
               Moyer.
             </p>
             <div className="flex flex-col justify-center gap-4 sm:flex-row">
+              <Link
+                href="/walk-and-talk"
+                className="rounded-full bg-white px-8 py-3 font-semibold text-gray-900 transition-colors hover:bg-gray-100"
+              >
+                Book a Walk and Talk
+              </Link>
               <a
                 href="https://linkedin.com/in/clarkemoyer"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="rounded-full bg-white px-8 py-3 font-semibold text-gray-900 transition-colors hover:bg-gray-100"
+                className="rounded-full border border-white px-8 py-3 font-semibold text-white transition-colors hover:bg-white/10"
               >
                 Connect on LinkedIn
               </a>
               <a
                 href="#projects"
-                className="rounded-full bg-brand px-8 py-3 font-semibold text-white transition-colors hover:bg-brand-hover"
+                className="rounded-full border border-white/70 px-8 py-3 font-semibold text-white transition-colors hover:bg-white/10"
               >
                 View Projects
               </a>
-              <Link
-                href="/walk-and-talk"
-                className="rounded-full border border-white px-8 py-3 font-semibold text-white transition-colors hover:bg-white/10"
-              >
-                Book a Walk and Talk
-              </Link>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Makes Book a Walk and Talk the first and only filled primary hero CTA
- Downgrades LinkedIn and View Projects to secondary outline CTAs so Walk and Talk is visually dominant
- Updates homepage visual-polish regression tests to preserve this CTA hierarchy

## Test Plan
- npm run lint
- npm test -- --runInBand
- npm run test:images
- npm run build
- npm run test:e2e

## Visual check
- Local mobile screenshot verified that Book a Walk and Talk is unmistakably primary.
