### PR TITLE
fix: extend walk and talk CTA hierarchy

### DIFF
--- a/__tests__/pages/contact-walk-talk-cta.test.tsx
+++ b/__tests__/pages/contact-walk-talk-cta.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { render, screen, within } from '@testing-library/react'
+import ContactPage from '../../src/app/contact/page'
+import WhoIAmPage from '../../src/app/who-i-am/page'
+import CTAButtons from '../../src/components/CTAButtons'
+
+describe('sitewide Walk and Talk CTA hierarchy', () => {
+  it('makes Walk and Talk the first and strongest contact option', () => {
+    render(<ContactPage />)
+
+    const contactLinks = screen.getAllByRole('link')
+    const walkAndTalk = screen.getByRole('link', { name: /Book a Walk and Talk/i })
+    const textLink = screen.getByRole('link', { name: /Text/i })
+    const linkedIn = screen.getByRole('link', { name: /Connect with Clarke Moyer on LinkedIn/i })
+
+    expect(contactLinks.indexOf(walkAndTalk)).toBeLessThan(contactLinks.indexOf(textLink))
+    expect(contactLinks.indexOf(walkAndTalk)).toBeLessThan(contactLinks.indexOf(linkedIn))
+    expect(walkAndTalk).toHaveClass('bg-white')
+    expect(textLink).toHaveClass('border')
+    expect(linkedIn).toHaveClass('border')
+  })
+
+  it('gives the Who I Am page a primary Walk and Talk closer before LinkedIn', () => {
+    render(<WhoIAmPage />)
+
+    const topCtaRegion = screen.getByTestId('who-i-am-top-cta')
+    const topCtaLinks = within(topCtaRegion).getAllByRole('link')
+    const topWalkAndTalk = within(topCtaRegion).getByRole('link', {
+      name: /Book a Walk and Talk/i,
+    })
+
+    expect(topCtaLinks[0]).toBe(topWalkAndTalk)
+    expect(topWalkAndTalk).toHaveClass('bg-blue-600')
+
+    const ctaRegion = screen.getByTestId('who-i-am-cta')
+    const ctaLinks = within(ctaRegion).getAllByRole('link')
+    const walkAndTalk = within(ctaRegion).getByRole('link', { name: /Book a Walk and Talk/i })
+    const linkedIn = within(ctaRegion).getByRole('link', { name: /Connect on LinkedIn/i })
+
+    expect(ctaLinks[0]).toBe(walkAndTalk)
+    expect(walkAndTalk).toHaveAttribute('href', '/walk-and-talk')
+    expect(walkAndTalk).toHaveClass('bg-blue-600')
+    expect(linkedIn).toHaveClass('border')
+  })
+
+  it('makes shared CTAButtons lead with Walk and Talk', () => {
+    render(<CTAButtons />)
+
+    const links = screen.getAllByRole('link')
+    const walkAndTalk = screen.getByRole('link', { name: /Book a Walk and Talk/i })
+
+    expect(links[0]).toBe(walkAndTalk)
+    expect(walkAndTalk).toHaveAttribute('href', '/walk-and-talk')
+    expect(walkAndTalk).toHaveClass('bg-blue-600')
+    expect(screen.getByRole('link', { name: /Connect on LinkedIn/i })).toHaveClass('border')
+  })
+})

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,6 +1,6 @@
-import type { Metadata } from 'next';
-import Link from 'next/link';
-import { breadcrumbSchema, SchemaScript } from '@/lib/schema';
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { breadcrumbSchema, SchemaScript } from '@/lib/schema'
 
 export const metadata: Metadata = {
   title: 'Contact',
@@ -13,10 +13,10 @@ export const metadata: Metadata = {
     type: 'website',
     url: '/contact/',
   },
-};
+}
 
 const BOOK_MAIN =
-  'https://outlook.office.com/bookwithme/user/6a2b9209a2654d8e9f83499a2218eec3@moyermanagement.com?anonymous&ismsaljsauthenabled&ep=plink';
+  'https://outlook.office.com/bookwithme/user/6a2b9209a2654d8e9f83499a2218eec3@moyermanagement.com?anonymous&ismsaljsauthenabled&ep=plink'
 
 export default function ContactPage() {
   return (
@@ -29,10 +29,12 @@ export default function ContactPage() {
       />
 
       {/* Hero */}
-      <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center pt-28 pb-16 px-4">
+      <section className="relative bg-gray-900 flex items-center justify-center pt-24 pb-12 px-4 md:min-h-[40vh] md:pt-28 md:pb-16">
         <div className="text-center text-white max-w-3xl">
           <nav aria-label="Breadcrumb" className="text-sm mb-4">
-            <Link href="/" className="hover:underline text-gray-300">Home</Link>
+            <Link href="/" className="hover:underline text-gray-300">
+              Home
+            </Link>
             {' / '}
             <span className="text-gray-400">Contact</span>
           </nav>
@@ -45,19 +47,42 @@ export default function ContactPage() {
 
       {/* Contact options */}
       <section className="bg-white py-16">
-        <div className="max-w-3xl mx-auto px-4">
+        <div className="max-w-3xl mx-auto px-4 pb-32 md:pb-0">
+          {/* Book directly */}
+          <div className="bg-gray-900 rounded-2xl p-8 mb-6 text-white flex flex-col md:flex-row items-center gap-6">
+            <div className="text-5xl" aria-hidden="true">
+              📅
+            </div>
+            <div className="flex-1">
+              <h2 className="text-2xl font-bold mb-2">Book a Walk and Talk</h2>
+              <p className="text-gray-300 mb-4">
+                Clarke&apos;s favorite way to connect: a focused conversation while walking through
+                the issue together.
+              </p>
+              <a
+                href={BOOK_MAIN}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block bg-white text-gray-900 font-bold px-8 py-3 rounded-full hover:bg-gray-100 transition-colors text-lg"
+              >
+                Book a Walk and Talk →
+              </a>
+            </div>
+          </div>
 
           {/* Text */}
-          <div className="bg-gray-900 rounded-2xl p-8 mb-6 text-white flex flex-col md:flex-row items-center gap-6">
-            <div className="text-5xl" aria-hidden="true">💬</div>
+          <div className="bg-white border border-gray-200 rounded-2xl p-8 mb-6 flex flex-col md:flex-row items-center gap-6 shadow-sm">
+            <div className="text-5xl" aria-hidden="true">
+              💬
+            </div>
             <div className="flex-1">
-              <h2 className="text-2xl font-bold mb-2">Send a Text</h2>
-              <p className="text-gray-300 mb-4">
-                The fastest way to reach Clarke. Text him directly — no voicemail, no gatekeeper.
+              <h2 className="text-2xl font-bold text-gray-900 mb-2">Send a Text</h2>
+              <p className="text-gray-700 mb-4">
+                Need a quick note first? Text Clarke directly — no voicemail, no gatekeeper.
               </p>
               <a
                 href="sms:5202228104"
-                className="inline-block bg-white text-gray-900 font-bold px-8 py-3 rounded-full hover:bg-gray-100 transition-colors text-lg"
+                className="inline-block border border-gray-900 text-gray-900 font-bold px-8 py-3 rounded-full hover:bg-gray-900 hover:text-white transition-colors text-lg"
               >
                 Text (520) 222-8104 →
               </a>
@@ -65,8 +90,10 @@ export default function ContactPage() {
           </div>
 
           {/* LinkedIn */}
-          <div className="bg-blue-50 border border-blue-200 rounded-2xl p-8 mb-6 flex flex-col md:flex-row items-center gap-6">
-            <div className="text-5xl" aria-hidden="true">🔗</div>
+          <div className="bg-blue-50 border border-blue-200 rounded-2xl p-8 mb-10 flex flex-col md:flex-row items-center gap-6">
+            <div className="text-5xl" aria-hidden="true">
+              🔗
+            </div>
             <div className="flex-1">
               <h2 className="text-2xl font-bold text-blue-900 mb-2">Connect on LinkedIn</h2>
               <p className="text-blue-800 mb-4">
@@ -76,28 +103,10 @@ export default function ContactPage() {
                 href="https://www.linkedin.com/in/clarkemoyer"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-block bg-blue-700 hover:bg-blue-800 text-white font-bold px-8 py-3 rounded-full transition-colors text-lg"
+                aria-label="Connect with Clarke Moyer on LinkedIn"
+                className="inline-block border border-blue-700 text-blue-800 font-bold px-8 py-3 rounded-full hover:bg-blue-700 hover:text-white transition-colors text-lg"
               >
-                LinkedIn: Clarke Moyer →
-              </a>
-            </div>
-          </div>
-
-          {/* Book directly */}
-          <div className="bg-green-50 border border-green-200 rounded-2xl p-8 mb-10 flex flex-col md:flex-row items-center gap-6">
-            <div className="text-5xl" aria-hidden="true">📅</div>
-            <div className="flex-1">
-              <h2 className="text-2xl font-bold text-green-900 mb-2">Ready to Book?</h2>
-              <p className="text-green-800 mb-4">
-                Skip the back-and-forth — book a Walk and Talk session directly via Microsoft Bookings.
-              </p>
-              <a
-                href={BOOK_MAIN}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-block bg-green-700 hover:bg-green-800 text-white font-bold px-8 py-3 rounded-full transition-colors text-lg"
-              >
-                Book a Walk and Talk →
+                LinkedIn →
               </a>
             </div>
           </div>
@@ -107,17 +116,25 @@ export default function ContactPage() {
             <p className="font-bold text-amber-900">🎁 Nonprofit? Walk and Talk is free.</p>
             <p className="text-amber-800 text-sm mt-1">
               Registered 501(c)(3) nonprofits receive Walk and Talk at no cost through{' '}
-              <a href="https://freeforcharity.org" target="_blank" rel="noopener noreferrer" className="underline">
+              <a
+                href="https://freeforcharity.org"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
                 Free For Charity
-              </a>.
+              </a>
+              .
             </p>
           </div>
 
           <div className="text-center">
-            <Link href="/" className="text-blue-600 hover:underline font-medium">← Back to Home</Link>
+            <Link href="/" className="text-blue-600 hover:underline font-medium">
+              ← Back to Home
+            </Link>
           </div>
         </div>
       </section>
     </>
-  );
+  )
 }

--- a/src/app/who-i-am/page.tsx
+++ b/src/app/who-i-am/page.tsx
@@ -1,16 +1,18 @@
-import type { Metadata } from 'next';
-import Link from 'next/link';
+import type { Metadata } from 'next'
+import Link from 'next/link'
 
 export const metadata: Metadata = {
   title: 'Who I Am',
-  description: 'Learn about Clarke Moyer — husband, father, DoD contractor, Army veteran, education supporter, and charity founder.',
+  description:
+    'Learn about Clarke Moyer — husband, father, DoD contractor, Army veteran, education supporter, and charity founder.',
   openGraph: {
     title: 'Who I Am | Clarke Moyer',
-    description: 'Learn about Clarke Moyer — husband, father, DoD contractor, Army veteran, education supporter, and charity founder.',
+    description:
+      'Learn about Clarke Moyer — husband, father, DoD contractor, Army veteran, education supporter, and charity founder.',
     type: 'website',
     url: '/who-i-am/',
   },
-};
+}
 
 export default function WhoIAmPage() {
   return (
@@ -18,7 +20,10 @@ export default function WhoIAmPage() {
       <section className="relative min-h-[40vh] bg-gray-900 flex items-center justify-center py-24 px-4">
         <div className="text-center text-white">
           <div className="text-sm mb-2">
-            <Link href="/" className="hover:underline text-gray-300">Home</Link> / Who I Am
+            <Link href="/" className="hover:underline text-gray-300">
+              Home
+            </Link>{' '}
+            / Who I Am
           </div>
           <h1 className="text-5xl md:text-6xl font-bold">Who I Am</h1>
         </div>
@@ -27,64 +32,110 @@ export default function WhoIAmPage() {
       <section className="bg-white py-16">
         <div className="max-w-4xl mx-auto px-4 prose prose-lg">
           <p className="text-xl text-gray-600 mb-8">
-            Start your targeting packages here. This is a general introduction to who I am and what motivates me.
+            Start your targeting packages here. This is a general introduction to who I am and what
+            motivates me.
           </p>
+
+          <div
+            className="not-prose mb-12 rounded-2xl bg-blue-50 p-6 text-center shadow-sm ring-1 ring-blue-100"
+            data-testid="who-i-am-top-cta"
+          >
+            <p className="mb-4 text-lg font-semibold text-blue-950">
+              Prefer a conversation? Walk and Talk is the best place to start.
+            </p>
+            <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+              <Link
+                href="/walk-and-talk"
+                className="inline-block rounded-full bg-blue-600 px-8 py-3 font-semibold text-white no-underline transition-colors hover:bg-blue-700"
+              >
+                Book a Walk and Talk
+              </Link>
+              <a
+                href="https://linkedin.com/in/clarkemoyer"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block rounded-full border border-blue-600 px-8 py-3 font-semibold text-blue-700 no-underline transition-colors hover:bg-blue-50"
+              >
+                Connect on LinkedIn
+              </a>
+            </div>
+          </div>
 
           <h2>Husband and Father</h2>
           <p>
-            I am married to April Moyer and we have 2 children Autumn Moyer and Clarke S. Moyer. We focus on doing fun
-            things around the house and saving for great vacations. For pictures and a better view of my family life,
-            send me a friend request on Facebook.
+            I am married to April Moyer and we have 2 children Autumn Moyer and Clarke S. Moyer. We
+            focus on doing fun things around the house and saving for great vacations. For pictures
+            and a better view of my family life, send me a friend request on Facebook.
           </p>
 
           <h2>Education Supporter</h2>
           <p>
-            I started late into education. When getting out of the Army I did not think that I &ldquo;needed&rdquo; a college
-            education. Times have changed for me. I have now invested in myself through both technical certifications
-            and formal education.
+            I started late into education. When getting out of the Army I did not think that I
+            &ldquo;needed&rdquo; a college education. Times have changed for me. I have now invested
+            in myself through both technical certifications and formal education.
           </p>
           <p>
-            I currently hold over 10 certifications and trainings. For more information regarding my DoD and industry IT
-            certifications please visit my{' '}
-            <a href="https://linkedin.com/in/clarkemoyer" target="_blank" rel="noopener noreferrer">LinkedIn Page</a>.
+            I currently hold over 10 certifications and trainings. For more information regarding my
+            DoD and industry IT certifications please visit my{' '}
+            <a href="https://linkedin.com/in/clarkemoyer" target="_blank" rel="noopener noreferrer">
+              LinkedIn Page
+            </a>
+            .
           </p>
           <p>
-            For formal education, I hold a BS-IT and an MBA-ITM from WGU as well as a graduate certificate of project
-            management from UMUC. I am pursuing the PSU Smeal eDBA Program.
+            For formal education, I hold a BS-IT and an MBA-ITM from WGU as well as a graduate
+            certificate of project management from UMUC. I am pursuing the PSU Smeal eDBA Program.
           </p>
           <p>
-            I highly recommend WGU to anyone seeking to further their education. For more information please see my{' '}
-            <Link href="/wgu-referral">WGU alumni referral page</Link>.
+            I highly recommend WGU to anyone seeking to further their education. For more
+            information please see my <Link href="/wgu-referral">WGU alumni referral page</Link>.
           </p>
 
           <h2>DoD Contractor</h2>
           <p>
-            Since leaving the US Army as a 33W (35T) I have worked for several great companies and organizations. My
-            services have focused primarily on Agile information technology support. This support has spanned multiple
-            size organizations at different echelons across the government sector. For a full listing of my experience
-            and education please view my{' '}
-            <a href="https://linkedin.com/in/clarkemoyer" target="_blank" rel="noopener noreferrer">LinkedIn Page</a>.
+            Since leaving the US Army as a 33W (35T) I have worked for several great companies and
+            organizations. My services have focused primarily on Agile information technology
+            support. This support has spanned multiple size organizations at different echelons
+            across the government sector. For a full listing of my experience and education please
+            view my{' '}
+            <a href="https://linkedin.com/in/clarkemoyer" target="_blank" rel="noopener noreferrer">
+              LinkedIn Page
+            </a>
+            .
           </p>
           <p>I am currently employed by PSU-ARL.</p>
 
           <h2>Physical Investor / Charity Supporter</h2>
           <p>
-            Taking an active role in investing for the future is to me a critical part of anyone&rsquo;s life. Investing to
-            me means more than just stocks and bonds stashed away in a 401K. Taking a physical approach to investing I
-            hold many unique assets above and beyond stocks and bonds.
+            Taking an active role in investing for the future is to me a critical part of
+            anyone&rsquo;s life. Investing to me means more than just stocks and bonds stashed away
+            in a 401K. Taking a physical approach to investing I hold many unique assets above and
+            beyond stocks and bonds.
           </p>
           <p>
-            I have also founded a 501c3 non profit that helps to educate other nonprofits and charity staff on IT,
-            business and marketing topics. To learn more visit{' '}
-            <a href="https://freeforcharity.org" target="_blank" rel="noopener noreferrer">freeforcharity.org</a>.
+            I have also founded a 501c3 non profit that helps to educate other nonprofits and
+            charity staff on IT, business and marketing topics. To learn more visit{' '}
+            <a href="https://freeforcharity.org" target="_blank" rel="noopener noreferrer">
+              freeforcharity.org
+            </a>
+            .
           </p>
 
-          <div className="mt-12 text-center">
+          <div
+            className="mt-12 flex flex-col gap-4 pb-32 text-center sm:flex-row sm:justify-center md:pb-0"
+            data-testid="who-i-am-cta"
+          >
+            <Link
+              href="/walk-and-talk"
+              className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-semibold px-8 py-3 rounded-full transition-colors no-underline"
+            >
+              Book a Walk and Talk
+            </Link>
             <a
               href="https://linkedin.com/in/clarkemoyer"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-semibold px-8 py-3 rounded-full transition-colors no-underline"
+              className="inline-block border border-blue-600 text-blue-700 hover:bg-blue-50 font-semibold px-8 py-3 rounded-full transition-colors no-underline"
             >
               Connect on LinkedIn
             </a>
@@ -92,5 +143,5 @@ export default function WhoIAmPage() {
         </div>
       </section>
     </>
-  );
+  )
 }

--- a/src/components/CTAButtons.tsx
+++ b/src/components/CTAButtons.tsx
@@ -1,17 +1,23 @@
-import React from 'react';
+import React from 'react'
 
 interface CTAButtonsProps {
-  className?: string;
+  className?: string
 }
 
-export default function CTAButtons({ className = "" }: CTAButtonsProps) {
+export default function CTAButtons({ className = '' }: CTAButtonsProps) {
   return (
     <div className={`flex flex-col sm:flex-row gap-4 ${className}`}>
+      <a
+        href="/walk-and-talk"
+        className="px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors text-center"
+      >
+        Book a Walk and Talk
+      </a>
       <a
         href="https://linkedin.com/in/clarkemoyer"
         target="_blank"
         rel="noopener noreferrer"
-        className="px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors text-center"
+        className="px-6 py-3 border border-blue-600 text-blue-700 font-semibold rounded-lg hover:bg-blue-50 transition-colors text-center"
       >
         Connect on LinkedIn
       </a>
@@ -19,10 +25,10 @@ export default function CTAButtons({ className = "" }: CTAButtonsProps) {
         href="https://www.arl.army.mil/careers/"
         target="_blank"
         rel="noopener noreferrer"
-        className="px-6 py-3 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 transition-colors text-center"
+        className="px-6 py-3 border border-green-600 text-green-700 font-semibold rounded-lg hover:bg-green-50 transition-colors text-center"
       >
         Apply for Jobs at ARL
       </a>
     </div>
-  );
+  )
 }

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -208,19 +208,19 @@ export default function CookieConsent() {
   const banner = (
     <div className="fixed bottom-0 left-0 right-0 z-50 bg-white border-t-2 border-gray-200 shadow-2xl" role="region" aria-label="Cookie consent notice">
       <div className="max-w-7xl mx-auto p-3 sm:p-6">
-        <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-3 sm:gap-4">
+        <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-2 sm:gap-4">
           <div className="flex-1">
-            <h3 className="text-base font-bold text-gray-900 mb-1 sm:text-lg sm:mb-2">We Value Your Privacy</h3>
-            <p className="text-xs text-gray-600 mb-2 sm:text-sm sm:mb-3">We use cookies to improve your experience and analyze traffic. You can accept all, decline non-essential cookies, or customize your preferences.</p>
-            <div className="flex items-center gap-4 text-xs text-gray-500">
+            <h3 className="text-sm font-bold text-gray-900 mb-1 sm:text-lg sm:mb-2">We Value Your Privacy</h3>
+            <p className="text-xs text-gray-600 mb-1 sm:text-sm sm:mb-3">We use cookies to improve your experience and analyze traffic. Accept all, decline non-essential cookies, or customize your preferences.</p>
+            <div className="flex items-center gap-4 text-[11px] text-gray-500 sm:text-xs">
               <Link href="/privacy-policy" className="text-blue-600 hover:underline">Privacy Policy</Link>
               <Link href="/cookie-policy" className="text-blue-600 hover:underline">Cookie Policy</Link>
             </div>
           </div>
           <div className="grid w-full grid-cols-3 gap-2 md:flex md:w-auto">
-            <button onClick={handleDeclineAll} className="px-3 py-2 bg-gray-200 text-gray-700 rounded-lg font-semibold hover:bg-gray-300 transition-colors text-xs whitespace-nowrap sm:px-6 sm:py-2.5 sm:text-sm">Decline All</button>
-            <button onClick={handleCustomize} className="px-3 py-2 bg-gray-200 text-gray-700 rounded-lg font-semibold hover:bg-gray-300 transition-colors text-xs whitespace-nowrap sm:px-6 sm:py-2.5 sm:text-sm">Customize</button>
-            <button onClick={handleAcceptAll} className="px-3 py-2 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition-colors text-xs whitespace-nowrap sm:px-6 sm:py-2.5 sm:text-sm">Accept All</button>
+            <button onClick={handleDeclineAll} className="px-3 py-2 bg-gray-200 text-gray-700 rounded-lg font-semibold hover:bg-gray-300 transition-colors text-[11px] whitespace-nowrap sm:px-6 sm:py-2.5 sm:text-sm">Decline All</button>
+            <button onClick={handleCustomize} className="px-3 py-2 bg-gray-200 text-gray-700 rounded-lg font-semibold hover:bg-gray-300 transition-colors text-[11px] whitespace-nowrap sm:px-6 sm:py-2.5 sm:text-sm">Customize</button>
+            <button onClick={handleAcceptAll} className="px-3 py-2 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition-colors text-[11px] whitespace-nowrap sm:px-6 sm:py-2.5 sm:text-sm">Accept All</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Extend the Walk and Talk CTA hierarchy beyond the homepage into contact, Who I Am, and shared CTA button patterns
- Make the contact page lead with a prominent Walk and Talk booking card, with text and LinkedIn as secondary contact options
- Add an earlier Who I Am CTA card so Walk and Talk appears before the long bio content
- Tighten the mobile cookie banner and add bottom spacing so CTAs remain easier to use on small screens
- Add regression tests that preserve Walk and Talk as the first/primary CTA in these shared/page contexts

## Verification
- `npm run lint`
- `npm test -- --runInBand`
- `npm run test:images`
- `npm run build`
- `npm run test:e2e`
- Mobile visual smoke screenshots reviewed for `/contact/` and `/who-i-am/`

## Scope
- Only `clarkemoyer.com` changed in this follow-up.
- `focus-on-free.com` was audited, but no additional changes were needed after the previous homepage/contact CTA work.
- `freeforcharity.org` was not touched.
