### PR TITLE
fix: hide cookie preferences until consent is stored

### DIFF
--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -64,6 +64,7 @@ export default function CookieConsent() {
     const secure = typeof window !== 'undefined' && window.location.protocol === 'https:' ? '; Secure' : ''
     document.cookie = `cookie-consent=${val}; path=/; max-age=31536000; SameSite=Lax${secure}`
     try { localStorage.setItem('cookie-consent', JSON.stringify(prefs)) } catch { /* ignore */ }
+    window.dispatchEvent(new Event('cookie-consent-updated'))
   }, [])
 
   const applyAnalytics = useCallback((prefs: CookiePreferences) => {

--- a/src/components/cookie-preferences-button/index.tsx
+++ b/src/components/cookie-preferences-button/index.tsx
@@ -1,10 +1,37 @@
 'use client'
 
+import { useEffect, useState } from 'react'
+
 interface CookiePreferencesButtonProps {
   className?: string
 }
 
+function hasStoredConsent() {
+  try {
+    if (localStorage.getItem('cookie-consent')) return true
+  } catch { /* ignore */ }
+
+  return /(?:^|;\s*)cookie-consent=/.test(document.cookie)
+}
+
 export default function CookiePreferencesButton({ className }: CookiePreferencesButtonProps) {
+  const [canOpenPreferences, setCanOpenPreferences] = useState(false)
+
+  useEffect(() => {
+    const refreshVisibility = () => setCanOpenPreferences(hasStoredConsent())
+
+    refreshVisibility()
+    window.addEventListener('cookie-consent-updated', refreshVisibility)
+    window.addEventListener('storage', refreshVisibility)
+
+    return () => {
+      window.removeEventListener('cookie-consent-updated', refreshVisibility)
+      window.removeEventListener('storage', refreshVisibility)
+    }
+  }, [])
+
+  if (!canOpenPreferences) return null
+
   return (
     <button
       type="button"

--- a/tests/cookie-consent.spec.ts
+++ b/tests/cookie-consent.spec.ts
@@ -35,6 +35,20 @@ test.describe('Cookie Consent Banner', () => {
     await expect(banner).not.toBeVisible()
   })
 
+  test('footer Cookie Preferences is hidden until consent is stored', async ({ page }) => {
+    const banner = page.locator('[role="region"][aria-label="Cookie consent notice"]')
+    if (await banner.count() === 0) { test.skip(); return }
+
+    const footerPreferences = page.locator('footer').getByRole('button', { name: 'Cookie Preferences' })
+    await expect(footerPreferences).toHaveCount(0)
+
+    await page.getByRole('button', { name: 'Accept All' }).click()
+    await expect(footerPreferences).toBeVisible()
+
+    await footerPreferences.click()
+    await expect(page.locator('[role="dialog"][aria-modal="true"]')).toBeVisible()
+  })
+
   test('Customize opens modal', async ({ page }) => {
     const banner = page.locator('[role="region"][aria-label="Cookie consent notice"]')
     if (await banner.count() === 0) { test.skip(); return }


### PR DESCRIPTION
## Summary
- Hide the footer Cookie Preferences control until a consent choice is stored, preventing the first-visit banner from covering/intercepting the footer control during QA and user interaction.
- Dispatch a small `cookie-consent-updated` browser event after saving consent so the footer control appears immediately after Accept/Decline/Save.
- Add Playwright coverage for the first-visit hidden state and post-consent reopen flow.

## Test Plan
- `npm run lint`
- `npm run build`
- `npx playwright test tests/cookie-consent.spec.ts`
- `frontend-qa --url http://127.0.0.1:3000 --out /tmp/clarkemoyer-cookie-qa --max-pages 1 --max-clicks-per-page 8 --mobile`

## QA Notes
- Local QA report: `/tmp/clarkemoyer-cookie-qa/report.md`
- Screenshots: `/tmp/clarkemoyer-cookie-qa/screenshots`
- The prior first-visit `Cookie Preferences` click timeout is gone; the QA run now reports 7 controls and no `Cookie Preferences` interaction problem.

## Privacy Gate
- Inspected `git status`, unstaged diff, staged diff, and changed files.
- Changed files are limited to cookie consent UI code and a Playwright spec.
- No credentials, private artifacts, logs, screenshots, chat/session data, or local runtime state were added.
